### PR TITLE
Adding headless management

### DIFF
--- a/src/main/java/com/threerings/getdown/data/Application.java
+++ b/src/main/java/com/threerings/getdown/data/Application.java
@@ -5,8 +5,7 @@
 
 package com.threerings.getdown.data;
 
-import java.awt.Color;
-import java.awt.Rectangle;
+import java.awt.*;
 import java.io.*;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
@@ -19,6 +18,7 @@ import java.nio.channels.OverlappingFileLockException;
 import java.security.*;
 import java.security.cert.Certificate;
 import java.util.*;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -633,6 +633,11 @@ public class Application
         // Add the launch specific JVM arguments
         for (String arg : _extraJvmArgs) {
             _jvmargs.add(arg);
+        }
+
+        // If we are headless, the target application should be headless
+        if(GraphicsEnvironment.isHeadless()) {
+            _jvmargs.add("-Djava.awt.headless=true");
         }
 
         // get the set of optimum JVM arguments


### PR DESCRIPTION
We are using GetDown to launch a Headless application on a Linux box that haven't any graphical environment installed.
We've modified the way we're launching GetDown to add ```-Djava.awt.headless=true``` parameter, and GetDown runs just fine, but unfortunately this parameter is not provided to the target application.
