### PR TITLE
added support for https proxies

### DIFF
--- a/src/main/java/com/threerings/getdown/data/Application.java
+++ b/src/main/java/com/threerings/getdown/data/Application.java
@@ -918,6 +918,8 @@ public class Application
         if ((proxyHost = System.getProperty("http.proxyHost")) != null) {
             args.add("-Dhttp.proxyHost=" + proxyHost);
             args.add("-Dhttp.proxyPort=" + System.getProperty("http.proxyPort"));
+            args.add("-Dhttps.proxyHost=" + proxyHost);
+            args.add("-Dhttps.proxyPort=" + System.getProperty("http.proxyPort"));
         }
 
         // add the marker indicating the app is running in getdown

--- a/src/main/java/com/threerings/getdown/launcher/Getdown.java
+++ b/src/main/java/com/threerings/getdown/launcher/Getdown.java
@@ -344,8 +344,10 @@ public abstract class Getdown extends Thread
     {
         if (!StringUtil.isBlank(host)) {
             System.setProperty("http.proxyHost", host);
+            System.setProperty("https.proxyHost", host);
             if (!StringUtil.isBlank(port)) {
                 System.setProperty("http.proxyPort", port);
+                System.setProperty("https.proxyPort", port);
             }
             log.info("Using proxy", "host", host, "port", port);
         }


### PR DESCRIPTION
At the moment getdown does not work with https proxies. This patch adds support for them by setting https proxy host and port variables.