### PR TITLE
Bugfix: for apps using -direct mode

### DIFF
--- a/src/main/java/com/threerings/getdown/launcher/GetdownApp.java
+++ b/src/main/java/com/threerings/getdown/launcher/GetdownApp.java
@@ -171,7 +171,14 @@ public class GetdownApp
                 }
                 @Override
                 protected void exit (int exitCode) {
-                    System.exit(exitCode);
+                    if (invokeDirect()) {
+                        // Makes sure the "download" window really does go away (stays if nothing to download)
+                        disposeContainer();
+                    }
+                    else {
+                        // Calling exit on an directly invoked app would exit the app now! We call only for non-direct!
+                        System.exit(exitCode);
+                    }
                 }
                 protected JFrame _frame;
             };


### PR DESCRIPTION
I was running into problems using GetdownApp in -direct mode. The app was force-closing because System.exit(...) was called. Also, in addition, the download window didn't go away (because most likely re-created).

Bugfix:
(a) prevents an app from closing in direct-mode
(b) force close the download window (doesn't go away if there is nothing to download).