### PR TITLE
added path to jregistrykey so that maven is able to compile the project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,8 @@
       <groupId>jregistrykey</groupId>
       <artifactId>jregistrykey</artifactId>
       <version>1.0</version>
+      <scope>system</scope>
+      <systemPath>${project.basedir}/lib/jregistrykey/jregistrykey/1.0/jregistrykey-1.0.jar</systemPath>
       <optional>true</optional>
     </dependency>
     <dependency>


### PR DESCRIPTION
At the moment the project cannot be compiled by maven without manually installing jregistrykey into the maven repository. This patch fixes this unfulfilled requirement by using the jregistrykey jar located in the lib folder.