### PR TITLE
Code quality fix - Utility classes should not have public constructors.

### DIFF
--- a/src/main/java/com/threerings/getdown/data/Properties.java
+++ b/src/main/java/com/threerings/getdown/data/Properties.java
@@ -10,6 +10,10 @@ package com.threerings.getdown.data;
  */
 public class Properties
 {
+    private Properties() {
+        
+    }
+    
     /** This property will be set to "true" on the application when it is being run by getdown. */
     public static final String GETDOWN = "com.threerings.getdown";
 

--- a/src/main/java/com/threerings/getdown/data/SysProps.java
+++ b/src/main/java/com/threerings/getdown/data/SysProps.java
@@ -15,6 +15,11 @@ import com.threerings.getdown.util.VersionUtil;
  */
 public class SysProps
 {
+    
+    private SysProps() {
+        
+    }
+    
     /** Configures the appdir (in lieu of passing it in argv). Usage: {@code -Dappdir=foo}. */
     public static String appDir () {
         return System.getProperty("appdir");

--- a/src/main/java/com/threerings/getdown/launcher/GetdownApp.java
+++ b/src/main/java/com/threerings/getdown/launcher/GetdownApp.java
@@ -34,6 +34,10 @@ import static com.threerings.getdown.Log.log;
  */
 public class GetdownApp
 {
+    private GetdownApp() {
+        
+    }
+    
     public static void main (String[] argv)
     {
         int aidx = 0;

--- a/src/main/java/com/threerings/getdown/tools/AppletParamSigner.java
+++ b/src/main/java/com/threerings/getdown/tools/AppletParamSigner.java
@@ -19,6 +19,10 @@ import org.apache.commons.codec.binary.Base64;
  */
 public class AppletParamSigner
 {
+    private AppletParamSigner() {
+        
+    }
+    
     public static void main (String[] args)
     {
         try {

--- a/src/main/java/com/threerings/getdown/tools/JarDiff.java
+++ b/src/main/java/com/threerings/getdown/tools/JarDiff.java
@@ -62,6 +62,10 @@ public class JarDiff implements JarDiffCodes
     // The JARDiff.java is the stand-alone jardiff.jar tool. Thus, we do not depend on Globals.java
     // and other stuff here. Instead, we use an explicit _debug flag.
     private static boolean _debug;
+    
+    private JarDiff() {
+        
+    }
 
     /**
      * Creates a patch from the two passed in files, writing the result to <code>os</code>.

--- a/src/main/java/com/threerings/getdown/util/ConfigUtil.java
+++ b/src/main/java/com/threerings/getdown/util/ConfigUtil.java
@@ -26,6 +26,10 @@ import static com.threerings.getdown.Log.log;
  */
 public class ConfigUtil
 {
+    private ConfigUtil() {
+        
+    }
+    
     /**
      * Parses a configuration file containing key/value pairs. The file must be in the UTF-8
      * encoding.

--- a/src/main/java/com/threerings/getdown/util/ConnectionUtil.java
+++ b/src/main/java/com/threerings/getdown/util/ConnectionUtil.java
@@ -15,6 +15,10 @@ import org.apache.commons.codec.binary.Base64;
 
 public class ConnectionUtil
 {
+    private ConnectionUtil() {
+        
+    }
+    
     /**
      * Opens a connection to a URL, setting the authentication header if user info is present.
      */

--- a/src/main/java/com/threerings/getdown/util/LaunchUtil.java
+++ b/src/main/java/com/threerings/getdown/util/LaunchUtil.java
@@ -22,6 +22,10 @@ import static com.threerings.getdown.Log.log;
  */
 public class LaunchUtil
 {
+    private LaunchUtil() {
+        
+    }
+    
     /** The directory into which a local VM installation should be unpacked. */
     public static final String LOCAL_JAVA_DIR = "java_vm";
 

--- a/src/main/java/com/threerings/getdown/util/VersionUtil.java
+++ b/src/main/java/com/threerings/getdown/util/VersionUtil.java
@@ -27,6 +27,10 @@ import static com.threerings.getdown.Log.log;
  */
 public class VersionUtil
 {
+    private VersionUtil() {
+        
+    }
+    
     /**
      * Reads a version number from a file.
      */


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
 
Please let me know if you have any questions.

Faisal Hameed