### PR TITLE
Code quality fix - Methods and field names should not be the same or differ only by capitalization.

### DIFF
--- a/src/main/java/com/threerings/getdown/launcher/Getdown.java
+++ b/src/main/java/com/threerings/getdown/launcher/Getdown.java
@@ -671,7 +671,7 @@ public abstract class Getdown extends Thread
                 mprog.startElement(1);
                 try {
                     Patcher patcher = new Patcher();
-                    patcher.patch(prsrc.getLocal().getParentFile(), prsrc.getLocal(), mprog);
+                    patcher.applyPatch(prsrc.getLocal().getParentFile(), prsrc.getLocal(), mprog);
                 } catch (Exception e) {
                     log.warning("Failed to apply patch", "prsrc", prsrc, e);
                 }

--- a/src/main/java/com/threerings/getdown/launcher/GetdownAppletConfig.java
+++ b/src/main/java/com/threerings/getdown/launcher/GetdownAppletConfig.java
@@ -59,9 +59,9 @@ public class GetdownAppletConfig
      * When a number is reached for which no value exists, we stop looking. */
     public static final String APPARG_PREFIX = "appargs";
 
-    public String appbase;
+    public String appBase;
 
-    public String appname;
+    public String appName;
 
     /** The list of background images and their display time */
     public String imgpath;
@@ -108,10 +108,10 @@ public class GetdownAppletConfig
         _applet = applet;
         _prefix = paramPrefix;
 
-        appbase = getParameter(APPBASE, "");
-        appname = getParameter(APPNAME, "");
-        log.info("App Base: " + appbase);
-        log.info("App Name: " + appname);
+        appBase = getParameter(APPBASE, "");
+        appName = getParameter(APPNAME, "");
+        log.info("App Base: " + appBase);
+        log.info("App Name: " + appName);
 
         imgpath = getParameter(BGIMAGE);
         errorimgpath = getParameter(ERRORBGIMAGE);
@@ -146,7 +146,7 @@ public class GetdownAppletConfig
             root = ".getdown";
         }
         appdir = new File(System.getProperty("user.home") + File.separator + root + File.separator
-            + appname);
+            + appName);
 
         installerFileContents = getParameter("installer");
 
@@ -370,10 +370,10 @@ public class GetdownAppletConfig
             try {
                 Map<String,Object> cdata = ConfigUtil.parseConfig(gdfile, false);
                 String oappbase = StringUtil.trim((String)cdata.get(APPBASE));
-                createGetdown = (appbase != null && !appbase.trim().equals(oappbase));
+                createGetdown = (appBase != null && !appBase.trim().equals(oappbase));
                 if (createGetdown) {
                     log.warning("Recreating getdown.txt due to appbase mismatch",
-                                "nappbase", appbase, "oappbase", oappbase);
+                                "nappbase", appBase, "oappbase", oappbase);
                 }
             } catch (Exception e) {
                 log.warning("Failure checking validity of getdown.txt, forcing recreate.",
@@ -382,10 +382,10 @@ public class GetdownAppletConfig
             }
         }
         if (createGetdown) {
-            if (StringUtil.isBlank(appbase)) {
+            if (StringUtil.isBlank(appBase)) {
                 throw new Exception("m.missing_appbase");
             }
-            if (!writeToFile(gdfile, "appbase = " + appbase)) {
+            if (!writeToFile(gdfile, "appbase = " + appBase)) {
                 throw new Exception("m.create_getdown_failed");
             }
         }

--- a/src/main/java/com/threerings/getdown/tools/Patcher.java
+++ b/src/main/java/com/threerings/getdown/tools/Patcher.java
@@ -49,7 +49,7 @@ public class Patcher
      * with the patcher so that the user interface is not blocked for the
      * duration of the patch.
      */
-    public void patch (File appdir, File patch, ProgressObserver obs)
+    public void applyPatch (File appdir, File patch, ProgressObserver obs)
         throws IOException
     {
         // save this information for later
@@ -206,7 +206,7 @@ public class Patcher
 
         Patcher patcher = new Patcher();
         try {
-            patcher.patch(new File(args[0]), new File(args[1]), null);
+            patcher.applyPatch(new File(args[0]), new File(args[1]), null);
         } catch (IOException ioe) {
             System.err.println("Error: " + ioe.getMessage());
             System.exit(-1);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1845 - Methods and field names should not be the same or differ only by capitalization.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1845

Please let me know if you have any questions.

Faisal Hameed