### PR TITLE
Code quality fix - Assignments should not be made from within sub-expressions.

### DIFF
--- a/src/main/java/com/threerings/getdown/data/Application.java
+++ b/src/main/java/com/threerings/getdown/data/Application.java
@@ -474,12 +474,15 @@ public class Application
             // otherwise, try reading data from our backup config file; thanks to funny windows
             // bullshit, we have to do this backup file fiddling in case we got screwed while
             // updating getdown.txt during normal operation
-            else if ((config = getLocalPath(CONFIG_FILE + "_old")).exists()) {
-                cdata = ConfigUtil.parseConfig(config, checkPlatform);
-            }
-            // otherwise, issue a warning that we found no getdown file
             else {
-                log.info("Found no getdown.txt file", "appdir", _appdir);
+                config = getLocalPath(CONFIG_FILE + "_old");
+                if (config.exists()) {
+                    cdata = ConfigUtil.parseConfig(config, checkPlatform);
+                }
+                // otherwise, issue a warning that we found no getdown file
+                else {
+                    log.info("Found no getdown.txt file", "appdir", _appdir);
+                }
             }
         } catch (Exception e) {
             log.warning("Failure reading config file", "file", config, e);

--- a/src/main/java/com/threerings/getdown/launcher/AbortPanel.java
+++ b/src/main/java/com/threerings/getdown/launcher/AbortPanel.java
@@ -46,11 +46,13 @@ public class AbortPanel extends JFrame
         add(new Spacer(5, 5));
 
         JPanel row = GroupLayout.makeButtonBox(GroupLayout.CENTER);
-        JButton button;
-        row.add(button = new JButton(get("m.abort_ok")));
+        JButton button = new JButton(get("m.abort_ok"));
+        row.add(button);
         button.setActionCommand("ok");
         button.addActionListener(this);
-        row.add(button = new JButton(get("m.abort_cancel")));
+        
+        button = new JButton(get("m.abort_cancel"));
+        row.add(button);
         button.setActionCommand("cancel");
         button.addActionListener(this);
         getRootPane().setDefaultButton(button);

--- a/src/main/java/com/threerings/getdown/launcher/ProxyPanel.java
+++ b/src/main/java/com/threerings/getdown/launcher/ProxyPanel.java
@@ -45,23 +45,27 @@ public class ProxyPanel extends JPanel
 
         JPanel row = new JPanel(new BorderLayout(5, 5));
         row.add(new JLabel(get("m.proxy_host")), BorderLayout.WEST);
-        row.add(_host = new SaneTextField());
+        _host = new SaneTextField();
+        row.add(_host);
         add(row);
 
         row = new JPanel(new BorderLayout(5, 5));
         row.add(new JLabel(get("m.proxy_port")), BorderLayout.WEST);
-        row.add(_port = new SaneTextField());
+        _port = new SaneTextField();
+        row.add(_port);
         add(row);
 
         add(new Spacer(5, 5));
         add(new JLabel(get("m.proxy_extra")));
 
         row = GroupLayout.makeButtonBox(GroupLayout.CENTER);
-        JButton button;
-        row.add(button = new JButton(get("m.proxy_ok")));
+        JButton button = new JButton(get("m.proxy_ok"));
+        row.add(button);
         button.setActionCommand("ok");
         button.addActionListener(this);
-        row.add(button = new JButton(get("m.proxy_cancel")));
+        
+        button = new JButton(get("m.proxy_cancel"));
+        row.add(button);
         button.setActionCommand("cancel");
         button.addActionListener(this);
         add(row);

--- a/src/main/java/com/threerings/getdown/net/Downloader.java
+++ b/src/main/java/com/threerings/getdown/net/Downloader.java
@@ -180,7 +180,8 @@ public abstract class Downloader extends Thread
         throws IOException
     {
         // update the actual size for this resource (but don't let it shrink)
-        _sizes.put(rsrc, actualSize = Math.max(actualSize, _sizes.get(rsrc)));
+        actualSize = Math.max(actualSize, _sizes.get(rsrc));
+        _sizes.put(rsrc, actualSize);
 
         // update the current downloaded size for said resource; don't allow the downloaded bytes
         // to exceed the original claimed size of the resource, otherwise our progress will get

--- a/src/main/java/com/threerings/getdown/tools/Differ.java
+++ b/src/main/java/com/threerings/getdown/tools/Differ.java
@@ -228,7 +228,8 @@ public class Differ
     {
         FileInputStream fin = null;
         try {
-            StreamUtil.copy(fin = new FileInputStream(file), jout);
+            fin = new FileInputStream(file);
+            StreamUtil.copy(fin, jout);
         } finally {
             StreamUtil.close(fin);
         }

--- a/src/main/java/com/threerings/getdown/tools/Patcher.java
+++ b/src/main/java/com/threerings/getdown/tools/Patcher.java
@@ -148,7 +148,9 @@ public class Patcher
         InputStream in = null;
         FileOutputStream fout = null;
         try {
-            StreamUtil.copy(in = file.getInputStream(entry), fout = new FileOutputStream(patch));
+            in = file.getInputStream(entry);
+            fout = new FileOutputStream(patch);
+            StreamUtil.copy(in, fout);
             StreamUtil.close(fout);
             fout = null;
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:AssignmentInSubExpressionCheck - Assignments should not be made from within sub-expressions. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:AssignmentInSubExpressionCheck

Please let me know if you have any questions.

Faisal Hameed