### PR TITLE
General code quality fix-1

### DIFF
--- a/src/main/java/com/threerings/getdown/Log.java
+++ b/src/main/java/com/threerings/getdown/Log.java
@@ -13,5 +13,5 @@ import com.samskivert.util.Logger;
 public class Log
 {
     /** We dispatch our log messages through this logger. */
-    public static Logger log = Logger.getLogger("com.threerings.getdown");
+    public static final Logger log = Logger.getLogger("com.threerings.getdown");
 }

--- a/src/main/java/com/threerings/getdown/launcher/Getdown.java
+++ b/src/main/java/com/threerings/getdown/launcher/Getdown.java
@@ -391,7 +391,7 @@ public abstract class Getdown extends Thread
                 // Store the config modtime before waiting the delay amount of time
                 long lastConfigModtime = config.lastModified();
                 log.info("Waiting " + _delay + " minutes before beginning actual work.");
-                Thread.sleep(_delay * 60 * 1000);
+                Thread.sleep((long)_delay * 60 * 1000);
                 if (lastConfigModtime < config.lastModified()) {
                     log.warning("getdown.txt was modified while getdown was waiting.");
                     throw new MultipleGetdownRunning();

--- a/src/main/java/com/threerings/getdown/tools/JarDiff.java
+++ b/src/main/java/com/threerings/getdown/tools/JarDiff.java
@@ -43,6 +43,7 @@ package com.threerings.getdown.tools;
 
 import java.io.*;
 import java.util.*;
+import java.util.Map.Entry;
 import java.util.jar.*;
 
 /**
@@ -168,9 +169,9 @@ public class JarDiff implements JarDiffCodes
             if (_debug) {
                 //DEBUG:  print out moved map
                 System.out.println("MOVED MAP!!!");
-                for (String newName : moved.keySet()) {
-                    String oldName = moved.get(newName);
-                    System.out.println("key is " + newName + " value is " + oldName);
+                for (Entry<String, String> movedEntries : moved.entrySet()) {
+                    String oldName = movedEntries.getValue();
+                    System.out.println("key is " + movedEntries.getKey() + " value is " + oldName);
                 }
 
                 //DEBUG:  print out IMOVE map
@@ -235,13 +236,13 @@ public class JarDiff implements JarDiffCodes
         }
 
         // And those that have moved
-        for (String newName : movedMap.keySet()) {
-            String oldName = movedMap.get(newName);
+        for (Entry<String, String> movedEntries : movedMap.entrySet()) {
+            String oldName = movedEntries.getValue();
             writer.write(MOVE_COMMAND);
             writer.write(" ");
             writeEscapedString(writer, oldName);
             writer.write(" ");
-            writeEscapedString(writer, newName);
+            writeEscapedString(writer, movedEntries.getKey());
             writer.write("\r\n");
         }
 

--- a/src/main/java/com/threerings/getdown/tools/JarDiffPatcher.java
+++ b/src/main/java/com/threerings/getdown/tools/JarDiffPatcher.java
@@ -76,7 +76,7 @@ public class JarDiffPatcher implements JarDiffCodes
             // since oldjarNames.size() changes in the first two loop below, we
             // need to adjust the size accordingly also when oldjarNames.size()
             // changes
-            double size = oldjarNames.size() + keys.length + jarDiff.size();
+            double size = (double)oldjarNames.size() + keys.length + jarDiff.size();
             double currentEntry = 0;
 
             // Handle all remove commands


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules 
squid:S2864 - "entrySet()" should be iterated when both the key and value are needed.
squid:S2184 - Math operands should be cast before assignment.
squid:S1444 - "public static" fields should be constant
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2184
https://dev.eclipse.org/sonar/rules/show/squid:S2864
https://dev.eclipse.org/sonar/rules/show/squid:S1444

Please let me know if you have any questions.

Faisal Hameed