### PR TITLE
Avoid corrupted resources when download is interrupted

### DIFF
--- a/src/main/java/com/threerings/getdown/data/Resource.java
+++ b/src/main/java/com/threerings/getdown/data/Resource.java
@@ -13,7 +13,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
-import java.util.jar.JarInputStream;
 
 import com.samskivert.io.StreamUtil;
 import com.samskivert.util.StringUtil;
@@ -36,6 +35,7 @@ public class Resource
         _path = path;
         _remote = remote;
         _local = local;
+        _local_new = new File(local.toString() + "_new");
         String lpath = _local.getPath();
         _marker = new File(lpath + "v");
 
@@ -65,6 +65,11 @@ public class Resource
     public File getLocal ()
     {
         return _local;
+    }
+
+    public File getLocalNew ()
+    {
+    	return _local_new;
     }
 
     /**
@@ -107,7 +112,16 @@ public class Resource
     public String computeDigest (MessageDigest md, ProgressObserver obs)
         throws IOException
     {
-        return computeDigest(_local, md, obs);
+    	File file;
+    	if (_local.toString().toLowerCase().endsWith(Application.CONFIG_FILE))
+    		file = _local;
+    	else {
+    		if (_local_new.exists())
+    			file = _local_new;
+    		else
+    			file = _local;
+    	}
+        return computeDigest(file, md, obs);
     }
 
     /**
@@ -292,7 +306,7 @@ public class Resource
 
     protected static boolean isJar (String path)
     {
-        return path.endsWith(".jar");
+        return path.endsWith(".jar") || path.endsWith(".jar_new");
     }
 
     protected static boolean isPacked200Jar (String path)
@@ -302,7 +316,7 @@ public class Resource
 
     protected String _path;
     protected URL _remote;
-    protected File _local, _marker, _unpacked;
+    protected File _local, _local_new, _marker, _unpacked;
     protected boolean _unpack, _isJar, _isPacked200Jar;
 
     /** Used to sort the entries in a jar file. */

--- a/src/main/java/com/threerings/getdown/data/SysProps.java
+++ b/src/main/java/com/threerings/getdown/data/SysProps.java
@@ -49,6 +49,10 @@ public class SysProps
         return System.getProperty("silent") != null;
     }
 
+    public static boolean install () {
+    	return System.getProperty("no_install") == null;
+    }
+
     /** If true, Getdown installs the app without ever bringing up a UI and then launches it.
       * Usage: {@code -Dsilent=launch}. */
     public static boolean launchInSilent () {

--- a/src/main/java/com/threerings/getdown/launcher/Getdown.java
+++ b/src/main/java/com/threerings/getdown/launcher/Getdown.java
@@ -795,6 +795,10 @@ public abstract class Getdown extends Thread
     	}
     }
     
+    public static boolean isUpdateAvailable() {
+    	return readyToInstall && !toBeInstalledResouces.isEmpty();
+    }
+    
     /**
      * Called to launch the application if everything is determined to be ready to go.
      */

--- a/src/main/java/com/threerings/getdown/net/HTTPDownloader.java
+++ b/src/main/java/com/threerings/getdown/net/HTTPDownloader.java
@@ -78,7 +78,7 @@ public class HTTPDownloader extends Downloader
         long currentSize = 0L;
         try {
             in = conn.getInputStream();
-            out = new FileOutputStream(rsrc.getLocal());
+            out = new FileOutputStream(rsrc.getLocalNew());
             int read;
 
             // TODO: look to see if we have a download info file

--- a/src/main/java/com/threerings/getdown/util/FileUtil.java
+++ b/src/main/java/com/threerings/getdown/util/FileUtil.java
@@ -57,6 +57,7 @@ public class FileUtil extends com.samskivert.util.FileUtil
             fin = new FileInputStream(source);
             fout = new FileOutputStream(dest);
             StreamUtil.copy(fin, fout);
+            fin.close(); // needed otherwise cannot delete source
             if (!source.delete()) {
                 log.warning("Failed to delete " + source +
                             " after brute force copy to " + dest + ".");


### PR DESCRIPTION
1) Download resources first into a temporary file
2) Perform verification and digest comparison with the downloaded
temporary file instead of the original if temporary file exist
3) Only when verification completes successfully rename all the
temporary files to override the original. This step can be done
automatically or manually by calling GetDown.install() which is useful
for those who want to download in background and install upon program
exit.
