### PR TITLE
Change build source and target to Java 6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,8 +109,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.3</version>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.6</source>
+          <target>1.6</target>
           <fork>true</fork>
           <showDeprecation>true</showDeprecation>
           <showWarnings>true</showWarnings>


### PR DESCRIPTION
I've imported the project into Eclipse and the compiler told me that it cannot compile the sources with Java 5 compliance level. This is due to the `@Override` annotations used on implemented interface methods. That's a feature that has been introduced with Java 6.

When I change the `pom.xml` to use a JDK 5 compiler

    <executable>/path/to/jdk1.5.0_22/bin/javac.exe</executable>

Maven tells me basically the same when compiling the sources.