### PR TITLE
Basic re-formatting of source code

### DIFF
--- a/src/main/java/com/threerings/getdown/Log.java
+++ b/src/main/java/com/threerings/getdown/Log.java
@@ -10,8 +10,7 @@ import com.samskivert.util.Logger;
 /**
  * A placeholder class that contains a reference to the log object used by the Getdown code.
  */
-public class Log
-{
+public class Log {
     /** We dispatch our log messages through this logger. */
     public static final Logger log = Logger.getLogger("com.threerings.getdown");
 }

--- a/src/main/java/com/threerings/getdown/data/Application.java
+++ b/src/main/java/com/threerings/getdown/data/Application.java
@@ -68,11 +68,10 @@ import com.threerings.getdown.util.ProgressObserver;
 import com.threerings.getdown.util.VersionUtil;
 
 /**
- * Parses and provide access to the information contained in the <code>getdown.txt</code>
+ * Parses and provide access to the information contained in the {@code getdown.txt}
  * configuration file.
  */
-public class Application
-{
+public class Application {
     /** The name of our configuration file. */
     public static final String CONFIG_FILE = "getdown.txt";
 
@@ -90,14 +89,12 @@ public class Application
     public static final String MANIFEST_CLASS = "manifest";
 
     /** Used to communicate information about the UI displayed when updating the application. */
-    public static class UpdateInterface
-    {
+    public static class UpdateInterface {
         /**
          * The major steps involved in updating, along with some arbitrary percentages
          * assigned to them, to mark global progress.
          */
-        public enum Step
-        {
+        public enum Step {
             UPDATE_JAVA(10),
             VERIFY_METADATA(15, 65, 95),
             DOWNLOAD(40),
@@ -111,8 +108,7 @@ public class Application
             public final List<Integer> defaultPercents;
 
             /** Enum constructor. */
-            Step (int... percents)
-            {
+            Step(int... percents) {
                 this.defaultPercents = intsToList(percents);
             }
         }
@@ -184,15 +180,14 @@ public class Application
 
         /** Generates a string representation of this instance. */
         @Override
-        public String toString ()
-        {
-            return "[name=" + name + ", bg=" + background + ", bg=" + backgroundImage +
-                ", pi=" + progressImage + ", prect=" + progress + ", pt=" + progressText +
-                ", pb=" + progressBar + ", srect=" + status + ", st=" + statusText +
-                ", shadow=" + textShadow + ", err=" + installError + ", nrect=" + patchNotes +
-                ", notes=" + patchNotesUrl + ", stepPercentages=" + stepPercentages +
-                ", parect=" + playAgain + ", paimage=" + playAgainImage +
-                ", hideProgressText" + hideProgressText + "]";
+        public String toString() {
+            return "[name=" + name + ", bg=" + background + ", bg=" + backgroundImage
+                + ", pi=" + progressImage + ", prect=" + progress + ", pt=" + progressText
+                + ", pb=" + progressBar + ", srect=" + status + ", st=" + statusText
+                + ", shadow=" + textShadow + ", err=" + installError + ", nrect=" + patchNotes
+                + ", notes=" + patchNotesUrl + ", stepPercentages=" + stepPercentages
+                + ", parect=" + playAgain + ", paimage=" + playAgainImage
+                + ", hideProgressText" + hideProgressText + "]";
         }
 
         /** Initializer */
@@ -207,10 +202,9 @@ public class Application
      * Used by {@link #verifyMetadata} to communicate status in circumstances where it needs to
      * take network actions.
      */
-    public static interface StatusDisplay
-    {
+    public interface StatusDisplay {
         /** Requests that the specified status message be displayed. */
-        public void updateStatus (String message);
+        public void updateStatus(String message);
     }
 
     /**
@@ -221,7 +215,7 @@ public class Application
         public final List<Resource> codes;
         public final List<Resource> rsrcs;
 
-        public AuxGroup (String name, List<Resource> codes, List<Resource> rsrcs) {
+        public AuxGroup(String name, List<Resource> codes, List<Resource> rsrcs) {
             this.name = name;
             this.codes = Collections.unmodifiableList(codes);
             this.rsrcs = Collections.unmodifiableList(rsrcs);
@@ -233,13 +227,12 @@ public class Application
      *
      * @see #Application(File, String, List, String[], String[])
      */
-    public Application (File appdir, String appid)
-    {
+    public Application(File appdir, String appid) {
         this(appdir, appid, null, null, null);
     }
 
     /**
-     * Creates an application instance which records the location of the <code>getdown.txt</code>
+     * Creates an application instance which records the location of the {@code getdown.txt}
      * configuration file from the supplied application directory.
      *
      * @param appid usually null but a string identifier if a secondary application is desired to
@@ -250,22 +243,20 @@ public class Application
      * @param appargs additional arguments to pass on to launched application; these will be added
      * after the args in the getdown.txt file.
      */
-    public Application (File appdir, String appid, List<Certificate> signers,
-                        String[] jvmargs, String[] appargs)
-    {
+    public Application(File appdir, String appid, List<Certificate> signers, String[] jvmargs,
+            String[] appargs) {
         _appdir = appdir;
         _appid = appid;
-        _signers = (signers == null) ? Collections.<Certificate>emptyList() : signers;
+        _signers = signers == null ? Collections.<Certificate>emptyList() : signers;
         _config = getLocalPath(CONFIG_FILE);
-        _extraJvmArgs = (jvmargs == null) ? ArrayUtil.EMPTY_STRING : jvmargs;
-        _extraAppArgs = (appargs == null) ? ArrayUtil.EMPTY_STRING : appargs;
+        _extraJvmArgs = jvmargs == null ? ArrayUtil.EMPTY_STRING : jvmargs;
+        _extraAppArgs = appargs == null ? ArrayUtil.EMPTY_STRING : appargs;
     }
 
     /**
      * Returns a resource that refers to the application configuration file itself.
      */
-    public Resource getConfigResource ()
-    {
+    public Resource getConfigResource() {
         try {
             return createResource(CONFIG_FILE, false);
         } catch (Exception e) {
@@ -276,16 +267,14 @@ public class Application
     /**
      * Returns a list of the code {@link Resource} objects used by this application.
      */
-    public List<Resource> getCodeResources ()
-    {
+    public List<Resource> getCodeResources() {
         return _codes;
     }
 
     /**
      * Returns a list of the non-code {@link Resource} objects used by this application.
      */
-    public List<Resource> getResources ()
-    {
+    public List<Resource> getResources() {
         return _resources;
     }
 
@@ -293,8 +282,7 @@ public class Application
      * Returns a list of all the active {@link Resource} objects used by this application (code and
      * non-code).
      */
-    public List<Resource> getAllActiveResources ()
-    {
+    public List<Resource> getAllActiveResources() {
         List<Resource> allResources = new ArrayList<Resource>();
         allResources.addAll(getActiveCodeResources());
         allResources.addAll(getActiveResources());
@@ -304,8 +292,7 @@ public class Application
     /**
      * Returns the auxiliary resource group with the specified name, or null.
      */
-    public AuxGroup getAuxGroup (String name)
-    {
+    public AuxGroup getAuxGroup(String name) {
         return _auxgroups.get(name);
     }
 
@@ -314,8 +301,7 @@ public class Application
      * resource group is a collection of resource files that are not downloaded unless a group
      * token file is present in the application directory.
      */
-    public Iterable<AuxGroup> getAuxGroups ()
-    {
+    public Iterable<AuxGroup> getAuxGroups() {
         return _auxgroups.values();
     }
 
@@ -324,8 +310,7 @@ public class Application
      * groups should be ignored, activated groups should be downloaded and patched along with the
      * main resources.
      */
-    public boolean isAuxGroupActive (String auxgroup)
-    {
+    public boolean isAuxGroupActive(String auxgroup) {
         Boolean active = _auxactive.get(auxgroup);
         if (active == null) {
             // TODO: compare the contents with the MD5 hash of the auxgroup name and the client's
@@ -339,8 +324,7 @@ public class Application
     /**
      * Returns all main code resources and all code resources from active auxiliary resource groups.
      */
-    public List<Resource> getActiveCodeResources ()
-    {
+    public List<Resource> getActiveCodeResources() {
         ArrayList<Resource> codes = new ArrayList<Resource>();
         codes.addAll(getCodeResources());
         for (AuxGroup aux : getAuxGroups()) {
@@ -354,8 +338,7 @@ public class Application
     /**
      * Returns all non-code resources and all resources from active auxiliary resource groups.
      */
-    public List<Resource> getActiveResources ()
-    {
+    public List<Resource> getActiveResources() {
         ArrayList<Resource> rsrcs = new ArrayList<Resource>();
         rsrcs.addAll(getResources());
         for (AuxGroup aux : getAuxGroups()) {
@@ -373,15 +356,14 @@ public class Application
      * @param auxgroup the auxiliary resource group for which a patch resource is desired or null
      * for the main application patch resource.
      */
-    public Resource getPatchResource (String auxgroup)
-    {
+    public Resource getPatchResource(String auxgroup) {
         if (_targetVersion <= _version) {
             log.warning("Requested patch resource for up-to-date or non-versioned application",
                 "cvers", _version, "tvers", _targetVersion);
             return null;
         }
 
-        String infix = (auxgroup == null) ? "" : ("-" + auxgroup);
+        String infix = auxgroup == null ? "" : "-" + auxgroup;
         String pfile = "patch" + infix + _version + ".dat";
         try {
             URL remote = new URL(createVAppBase(_targetVersion), encodePath(pfile));
@@ -398,8 +380,7 @@ public class Application
      * place of the installed VM (in the case where the VM that launched Getdown does not meet the
      * application's version requirements) or null if no VM is available for this platform.
      */
-    public Resource getJavaVMResource ()
-    {
+    public Resource getJavaVMResource() {
         if (StringUtil.isBlank(_javaLocation)) {
             return null;
         }
@@ -419,8 +400,7 @@ public class Application
      * Returns a resource that can be used to download an archive containing all files belonging to
      * the application.
      */
-    public Resource getFullResource ()
-    {
+    public Resource getFullResource() {
         String file = "full";
         try {
             URL remote = new URL(createVAppBase(_targetVersion), encodePath(file));
@@ -438,8 +418,7 @@ public class Application
      *
      * @param event the event to be reported: start, jvm_start, jvm_complete, complete.
      */
-    public URL getTrackingURL (String event)
-    {
+    public URL getTrackingURL(String event) {
         try {
             String suffix = _trackingURLSuffix == null ? "" : _trackingURLSuffix;
             String ga = getGATrackingCode();
@@ -455,8 +434,7 @@ public class Application
      * initial download. Returns null if no tracking request was configured for the specified
      * percentage.
      */
-    public URL getTrackingProgressURL (int percent)
-    {
+    public URL getTrackingProgressURL(int percent) {
         if (_trackingPcts == null || !_trackingPcts.contains(percent)) {
             return null;
         }
@@ -466,16 +444,14 @@ public class Application
     /**
      * Returns the name of our tracking cookie or null if it was not set.
      */
-    public String getTrackingCookieName ()
-    {
+    public String getTrackingCookieName() {
         return _trackingCookieName;
     }
 
     /**
      * Returns the name of our tracking cookie system property or null if it was not set.
      */
-    public String getTrackingCookieProperty ()
-    {
+    public String getTrackingCookieProperty() {
         return _trackingCookieProperty;
     }
 
@@ -490,11 +466,10 @@ public class Application
      * @exception IOException thrown if there is an error reading the file or an error encountered
      * during its parsing.
      */
-    public UpdateInterface init (boolean checkPlatform)
-        throws IOException
-    {
-        Map<String,Object> cdata = null;
+    public UpdateInterface init(boolean checkPlatform) throws IOException {
+        Map<String, Object> cdata = null;
         File config = _config;
+
         try {
             // if we have a configuration file, read the data from it
             if (config.exists()) {
@@ -519,13 +494,13 @@ public class Application
         if (cdata == null) {
             String appbase = SysProps.appBase();
             log.info("Attempting to obtain 'appbase' from system property", "appbase", appbase);
-            cdata = new HashMap<String,Object>();
+            cdata = new HashMap<String, Object>();
             cdata.put("appbase", appbase);
         }
 
         // first determine our application base, this way if anything goes wrong later in the
         // process, our caller can use the appbase to download a new configuration file
-        _appbase = (String)cdata.get("appbase");
+        _appbase = (String) cdata.get("appbase");
         if (_appbase == null) {
             throw new RuntimeException("m.missing_appbase");
         }
@@ -538,19 +513,22 @@ public class Application
         _appbase = replaceDomain(_appbase);
 
         // extract our version information
-        String vstr = (String)cdata.get("version");
-        if (vstr != null) _version = parseLong(vstr, "m.invalid_version");
+        String vstr = (String) cdata.get("version");
+
+        if (vstr != null) {
+            _version = parseLong(vstr, "m.invalid_version");
+        }
 
         // if we are a versioned deployment, create a versioned appbase
         try {
-            _vappbase = (_version < 0) ? new URL(_appbase) : createVAppBase(_version);
+            _vappbase = _version < 0 ? new URL(_appbase) : createVAppBase(_version);
         } catch (MalformedURLException mue) {
             String err = MessageUtil.tcompose("m.invalid_appbase", _appbase);
             throw (IOException) new IOException(err).initCause(mue);
         }
 
         // check for a latest config URL
-        String latest = (String)cdata.get("latest");
+        String latest = (String) cdata.get("latest");
         if (latest != null) {
             latest = replaceDomain(latest);
             try {
@@ -560,34 +538,44 @@ public class Application
             }
         }
 
-        String appPrefix = StringUtil.isBlank(_appid) ? "" : (_appid + ".");
+        String appPrefix = StringUtil.isBlank(_appid) ? "" : _appid + ".";
 
         // determine our application class name
-        _class = (String)cdata.get(appPrefix + "class");
+        _class = (String) cdata.get(appPrefix + "class");
         if (_class == null) {
             throw new IOException("m.missing_class");
         }
 
         // check to see if we're using a custom java.version property and regex
-        vstr = (String)cdata.get("java_version_prop");
-        if (vstr != null) _javaVersionProp = vstr;
-        vstr = (String)cdata.get("java_version_regex");
-        if (vstr != null) _javaVersionRegex = vstr;
+        vstr = (String) cdata.get("java_version_prop");
+        if (vstr != null) {
+            _javaVersionProp = vstr;
+        }
+        vstr = (String) cdata.get("java_version_regex");
+        if (vstr != null) {
+            _javaVersionRegex = vstr;
+        }
 
         // check to see if we require a particular JVM version and have a supplied JVM
-        vstr = (String)cdata.get("java_version");
-        if (vstr != null) _javaMinVersion = parseLong(vstr, "m.invalid_java_version");
+        vstr = (String) cdata.get("java_version");
+        if (vstr != null) {
+            _javaMinVersion = parseLong(vstr, "m.invalid_java_version");
+        }
         // we support java_min_version as an alias of java_version; it better expresses the check
         // that's going on and better mirrors java_max_version
-        vstr = (String)cdata.get("java_min_version");
-        if (vstr != null) _javaMinVersion = parseLong(vstr, "m.invalid_java_version");
+        vstr = (String) cdata.get("java_min_version");
+        if (vstr != null) {
+            _javaMinVersion = parseLong(vstr, "m.invalid_java_version");
+        }
 
         // check to see if we require a particular max JVM version and have a supplied JVM
-        vstr = (String)cdata.get("java_max_version");
-        if (vstr != null) _javaMaxVersion = parseLong(vstr, "m.invalid_java_version");
+        vstr = (String) cdata.get("java_max_version");
+        if (vstr != null) {
+            _javaMaxVersion = parseLong(vstr, "m.invalid_java_version");
+        }
 
         // check to see if we require a particular JVM version and have a supplied JVM
-        vstr = (String)cdata.get("java_exact_version_required");
+        vstr = (String) cdata.get("java_exact_version_required");
         _javaExactVersionRequired = Boolean.parseBoolean(vstr);
 
         // this is a little weird, but when we're run from the digester, we see a String[] which
@@ -595,14 +583,14 @@ public class Application
         // need to know about that; when we're run in a real application there will be only one!
         Object javaloc = cdata.get("java_location");
         if (javaloc instanceof String) {
-            _javaLocation = (String)javaloc;
+            _javaLocation = (String) javaloc;
         }
 
         // determine whether we have any tracking configuration
-        _trackingURL = (String)cdata.get("tracking_url");
+        _trackingURL = (String) cdata.get("tracking_url");
 
         // check for tracking progress percent configuration
-        String trackPcts = (String)cdata.get("tracking_percents");
+        String trackPcts = (String) cdata.get("tracking_percents");
         if (!StringUtil.isBlank(trackPcts)) {
             _trackingPcts = new HashSet<Integer>();
             for (int pct : StringUtil.parseIntArray(trackPcts)) {
@@ -614,14 +602,14 @@ public class Application
         }
 
         // Check for tracking cookie configuration
-        _trackingCookieName = (String)cdata.get("tracking_cookie_name");
-        _trackingCookieProperty = (String)cdata.get("tracking_cookie_property");
+        _trackingCookieName = (String) cdata.get("tracking_cookie_name");
+        _trackingCookieProperty = (String) cdata.get("tracking_cookie_property");
 
         // Some app may need an extra suffix added to the tracking URL
-        _trackingURLSuffix = (String)cdata.get("tracking_url_suffix");
+        _trackingURLSuffix = (String) cdata.get("tracking_url_suffix");
 
         // Some app may need to generate google analytics code
-        _trackingGAHash = (String)cdata.get("tracking_ga_hash");
+        _trackingGAHash = (String) cdata.get("tracking_ga_hash");
 
         // clear our arrays as we may be reinitializing
         _codes.clear();
@@ -632,8 +620,8 @@ public class Application
         _txtJvmArgs.clear();
 
         // parse our code resources
-        if (ConfigUtil.getMultiValue(cdata, "code") == null &&
-            ConfigUtil.getMultiValue(cdata, "ucode") == null) {
+        if (ConfigUtil.getMultiValue(cdata, "code") == null
+                && ConfigUtil.getMultiValue(cdata, "ucode") == null) {
             throw new IOException("m.missing_code");
         }
         parseResources(cdata, "code", false, _codes);
@@ -679,7 +667,7 @@ public class Application
         fillAssignmentListFromPairs("extra.txt", _txtJvmArgs);
 
         // determine whether we want to allow offline operation (defaults to false)
-        _allowOffline = Boolean.parseBoolean((String)cdata.get("allow_offline"));
+        _allowOffline = Boolean.parseBoolean((String) cdata.get("allow_offline"));
 
         // look for a debug.txt file which causes us to run in java.exe on Windows so that we can
         // obtain a thread dump of the running JVM
@@ -687,39 +675,39 @@ public class Application
 
         // parse and return our application config
         UpdateInterface ui = new UpdateInterface();
-        _name = ui.name = (String)cdata.get("ui.name");
+        _name = ui.name = (String) cdata.get("ui.name");
         ui.progress = parseRect(cdata, "ui.progress", ui.progress);
         ui.progressText = parseColor(cdata, "ui.progress_text", ui.progressText);
-        ui.hideProgressText =  Boolean.parseBoolean((String)cdata.get("ui.hide_progress_text"));
+        ui.hideProgressText =  Boolean.parseBoolean((String) cdata.get("ui.hide_progress_text"));
         ui.progressBar = parseColor(cdata, "ui.progress_bar", ui.progressBar);
         ui.status = parseRect(cdata, "ui.status", ui.status);
         ui.statusText = parseColor(cdata, "ui.status_text", ui.statusText);
         ui.textShadow = parseColor(cdata, "ui.text_shadow", ui.textShadow);
-        ui.hideDecorations = Boolean.parseBoolean((String)cdata.get("ui.hide_decorations"));
-        ui.backgroundImage = (String)cdata.get("ui.background_image");
+        ui.hideDecorations = Boolean.parseBoolean((String) cdata.get("ui.hide_decorations"));
+        ui.backgroundImage = (String) cdata.get("ui.background_image");
         if (ui.backgroundImage == null) { // support legacy format
-            ui.backgroundImage = (String)cdata.get("ui.background");
+            ui.backgroundImage = (String) cdata.get("ui.background");
         }
         // and now ui.background can refer to the background color, but fall back to black
         // or white, depending on the brightness of the progressText
-        Color defaultBackground = (.5f < Color.RGBtoHSB(
+        Color defaultBackground = .5f < Color.RGBtoHSB(
                 ui.progressText.getRed(), ui.progressText.getGreen(), ui.progressText.getBlue(),
-                null)[2])
+                null)[2]
             ? Color.BLACK
             : Color.WHITE;
         ui.background = parseColor(cdata, "ui.background", defaultBackground);
-        ui.progressImage = (String)cdata.get("ui.progress_image");
+        ui.progressImage = (String) cdata.get("ui.progress_image");
         ui.rotatingBackgrounds = ConfigUtil.getMultiValue(cdata, "ui.rotating_background");
         ui.iconImages = ConfigUtil.getMultiValue(cdata, "ui.icon");
-        ui.errorBackground = (String)cdata.get("ui.error_background");
-        _dockIconPath = (String)cdata.get("ui.mac_dock_icon");
+        ui.errorBackground = (String) cdata.get("ui.error_background");
+        _dockIconPath = (String) cdata.get("ui.mac_dock_icon");
         if (_dockIconPath == null) {
             _dockIconPath = "../desktop.icns"; // use a sensible default
         }
 
         // On an installation error, where do we point the user.
         String installError = parseUrl(cdata, "ui.install_error", null);
-        ui.installError = (installError == null) ?
+        ui.installError = installError == null ?
             "m.default_install_error" : MessageUtil.taint(installError);
 
         // the patch notes bits
@@ -728,11 +716,11 @@ public class Application
 
         // the play again bits
         ui.playAgain = parseRect(cdata, "ui.play_again", ui.playAgain);
-        ui.playAgainImage = (String)cdata.get("ui.play_again_image");
+        ui.playAgainImage = (String) cdata.get("ui.play_again_image");
 
         // step progress percentages
         for (UpdateInterface.Step step : UpdateInterface.Step.values()) {
-            String spec = (String)cdata.get("ui.percents." + step.name());
+            String spec = (String) cdata.get("ui.percents." + step.name());
             if (spec != null) {
                 try {
                     ui.stepPercentages.put(step, intsToList(StringUtil.parseIntArray(spec)));
@@ -748,8 +736,7 @@ public class Application
     /**
      * Adds strings of the form pair0=pair1 to collector for each pair parsed out of pairLocation.
      */
-    protected void fillAssignmentListFromPairs (String pairLocation, List<String> collector)
-    {
+    protected void fillAssignmentListFromPairs(String pairLocation, List<String> collector) {
         File pairFile = getLocalPath(pairLocation);
         if (pairFile.exists()) {
             try {
@@ -771,17 +758,14 @@ public class Application
      * Returns a URL from which the specified path can be fetched. Our application base URL is
      * properly versioned and combined with the supplied path.
      */
-    public URL getRemoteURL (String path)
-        throws MalformedURLException
-    {
+    public URL getRemoteURL(String path) throws MalformedURLException {
         return new URL(_vappbase, encodePath(path));
     }
 
     /**
      * Returns the local path to the specified resource.
      */
-    public File getLocalPath (String path)
-    {
+    public File getLocalPath(String path) {
         return new File(_appdir, path);
     }
 
@@ -790,10 +774,11 @@ public class Application
      * version requirements or have what appears to be a version of the JVM that meets our
      * requirements.
      */
-    public boolean haveValidJavaVersion ()
-    {
+    public boolean haveValidJavaVersion() {
         // if we're doing no version checking, then yay!
-        if (_javaMinVersion == 0 && _javaMaxVersion == 0) return true;
+        if (_javaMinVersion == 0 && _javaMaxVersion == 0) {
+            return true;
+        }
 
         try {
             // parse the version out of the java.version (or custom) system property
@@ -823,16 +808,17 @@ public class Application
             }
 
             if (_javaExactVersionRequired) {
-                if (version == _javaMinVersion) return true;
-                else {
+                if (version == _javaMinVersion) {
+                    return true;
+                } else {
                     log.warning("An exact Java VM version is required.", "current", version,
                                 "required", _javaMinVersion);
                     return false;
                 }
             }
 
-            boolean minVersionOK = (_javaMinVersion == 0) || (version >= _javaMinVersion);
-            boolean maxVersionOK = (_javaMaxVersion == 0) || (version <= _javaMaxVersion);
+            boolean minVersionOK = _javaMinVersion == 0 || version >= _javaMinVersion;
+            boolean maxVersionOK = _javaMaxVersion == 0 || version <= _javaMaxVersion;
             return minVersionOK && maxVersionOK;
 
         } catch (RuntimeException re) {
@@ -849,16 +835,14 @@ public class Application
      * whether the launch is successful and, if necessary, trying again without the optimum
      * arguments.
      */
-    public boolean hasOptimumJvmArgs ()
-    {
+    public boolean hasOptimumJvmArgs() {
         return _optimumJvmArgs != null;
     }
 
     /**
      * Returns true if the app should attempt to run even if we have no Internet connection.
      */
-    public boolean allowOffline ()
-    {
+    public boolean allowOffline() {
         return _allowOffline;
     }
 
@@ -866,9 +850,7 @@ public class Application
      * Attempts to redownload the <code>getdown.txt</code> file based on information parsed from a
      * previous call to {@link #init}.
      */
-    public void attemptRecovery (StatusDisplay status)
-        throws IOException
-    {
+    public void attemptRecovery(StatusDisplay status) throws IOException {
         status.updateStatus("m.updating_metadata");
         downloadConfigFile();
     }
@@ -877,9 +859,7 @@ public class Application
      * Downloads and replaces the <code>getdown.txt</code> and <code>digest.txt</code> files with
      * those for the target version of our application.
      */
-    public void updateMetadata ()
-        throws IOException
-    {
+    public void updateMetadata() throws IOException {
         try {
             // update our versioned application base with the target version
             _vappbase = createVAppBase(_targetVersion);
@@ -894,7 +874,6 @@ public class Application
             // start the whole process over again
             downloadDigestFile();
             downloadConfigFile();
-
         } catch (IOException ex) {
             // if we are allowing offline execution, we want to allow the application to run in its
             // current form rather than aborting the entire process; to do this, we delete the
@@ -918,9 +897,7 @@ public class Application
      * @param optimum whether or not to include the set of optimum arguments (as opposed to falling
      * back).
      */
-    public Process createProcess (boolean optimum)
-        throws IOException
-    {
+    public Process createProcess(boolean optimum) throws IOException {
         ArrayList<String> args = new ArrayList<String>();
 
         // reconstruct the path to the JVM
@@ -962,7 +939,7 @@ public class Application
 
         // pass along any pass-through arguments
         for (Map.Entry<Object, Object> entry : System.getProperties().entrySet()) {
-            String key = (String)entry.getKey();
+            String key = (String) entry.getKey();
             if (key.startsWith(PROP_PASSTHROUGH_PREFIX)) {
                 key = key.substring(PROP_PASSTHROUGH_PREFIX.length());
                 args.add("-D" + key + "=" + entry.getValue());
@@ -1012,8 +989,7 @@ public class Application
      * If the application didn't provide any environment variables, null is returned to just use
      * the existing environment.
      */
-    protected String[] createEnvironment ()
-    {
+    protected String[] createEnvironment() {
         List<String> envvar = new ArrayList<String>();
         fillAssignmentListFromPairs("env.txt", envvar);
         if (envvar.isEmpty()) {
@@ -1036,8 +1012,7 @@ public class Application
     /**
      * Runs this application directly in the current VM.
      */
-    public void invokeDirect (JApplet applet)
-    {
+    public void invokeDirect(JApplet applet) {
         // create a custom class loader
         ArrayList<URL> jars = new ArrayList<URL>();
         for (Resource rsrc : getActiveCodeResources()) {
@@ -1050,7 +1025,7 @@ public class Application
         URLClassLoader loader = new URLClassLoader(
             jars.toArray(new URL[jars.size()]),
             ClassLoader.getSystemClassLoader()) {
-            @Override protected PermissionCollection getPermissions (CodeSource code) {
+            @Override protected PermissionCollection getPermissions(CodeSource code) {
                 Permissions perms = new Permissions();
                 perms.add(new AllPermission());
                 return perms;
@@ -1059,7 +1034,9 @@ public class Application
         Thread.currentThread().setContextClassLoader(loader);
 
         log.info("Configured URL class loader:");
-        for (URL url : jars) log.info("  " + url);
+        for (URL url : jars) {
+            log.info("  " + url);
+        }
 
         // configure any system properties that we can
         for (String jvmarg : _jvmargs) {
@@ -1077,10 +1054,10 @@ public class Application
         // pass along any pass-through arguments
         Map<String, String> passProps = new HashMap<String, String>();
         for (Map.Entry<Object, Object> entry : System.getProperties().entrySet()) {
-            String key = (String)entry.getKey();
+            String key = (String) entry.getKey();
             if (key.startsWith(PROP_PASSTHROUGH_PREFIX)) {
                 key = key.substring(PROP_PASSTHROUGH_PREFIX.length());
-                passProps.put(key, (String)entry.getValue());
+                passProps.put(key, (String) entry.getValue());
             }
         }
         // we can't set these in the above loop lest we get a ConcurrentModificationException
@@ -1093,7 +1070,9 @@ public class Application
 
         // prepare our app arguments
         String[] args = new String[_appargs.size()];
-        for (int ii = 0; ii < args.length; ii++) args[ii] = processArg(_appargs.get(ii));
+        for (int ii = 0; ii < args.length; ii++) {
+            args[ii] = processArg(_appargs.get(ii));
+        }
 
         try {
             log.info("Loading " + _class);
@@ -1115,8 +1094,7 @@ public class Application
     }
 
     /** Replaces the application directory and version in any argument. */
-    protected String processArg (String arg)
-    {
+    protected String processArg(String arg) {
         arg = arg.replace("%APPDIR%", _appdir.getAbsolutePath());
         arg = arg.replace("%VERSION%", String.valueOf(_version));
 
@@ -1127,7 +1105,9 @@ public class Application
             Matcher matcher = ENV_VAR_PATTERN.matcher(arg);
             while (matcher.find()) {
                 String varName = matcher.group(1), varValue = System.getenv(varName);
-                if (varName == null) varName = "MISSING:" + varName;
+                if (varName == null) {
+                    varName = "MISSING:" + varName;
+                }
                 matcher.appendReplacement(sb, varValue);
             }
             matcher.appendTail(sb);
@@ -1149,18 +1129,10 @@ public class Application
      * @exception IOException thrown if we encounter an unrecoverable error while verifying the
      * metadata.
      */
-    public boolean verifyMetadata (StatusDisplay status)
-        throws IOException
-    {
+    public boolean verifyMetadata(StatusDisplay status) throws IOException {
         log.info("Verifying application: " + _vappbase);
         log.info("Version: " + _version);
         log.info("Class: " + _class);
-//         log.info("Code: " +
-//                  StringUtil.toString(getCodeResources().iterator()));
-//         log.info("Resources: " +
-//                  StringUtil.toString(getActiveResources().iterator()));
-//         log.info("JVM Args: " + StringUtil.toString(_jvmargs.iterator()));
-//         log.info("App Args: " + StringUtil.toString(_appargs.iterator()));
 
         // this will read in the contents of the digest file and validate itself
         try {
@@ -1174,7 +1146,7 @@ public class Application
         if (_version == -1) {
             // make a note of the old meta-digest, if this changes we need to revalidate all of our
             // resources as one or more of them have also changed
-            String olddig = (_digest == null) ? "" : _digest.getMetaDigest();
+            String olddig = _digest == null ? "" : _digest.getMetaDigest();
             try {
                 status.updateStatus("m.checking");
                 downloadDigestFile();
@@ -1273,9 +1245,8 @@ public class Application
      * validated" resources filled in.
      * @param unpacked a set to populate with unpacked resources.
      */
-    public List<Resource> verifyResources (ProgressObserver obs, int[] alreadyValid,
-                                           Set<Resource> unpacked) throws InterruptedException
-    {
+    public List<Resource> verifyResources(ProgressObserver obs, int[] alreadyValid,
+            Set<Resource> unpacked) throws InterruptedException {
         List<Resource> rsrcs = getAllActiveResources();
         List<Resource> failures = new ArrayList<Resource>();
 
@@ -1328,7 +1299,7 @@ public class Application
             failures.add(rsrc);
         }
 
-        return (failures.size() == 0) ? null : failures;
+        return failures.size() == 0 ? null : failures;
     }
 
     /**
@@ -1336,13 +1307,12 @@ public class Application
      *
      * @param unpacked a set of resources to skip because they're already unpacked.
      */
-    public void unpackResources (ProgressObserver obs, Set<Resource> unpacked)
-        throws InterruptedException
-    {
+    public void unpackResources(ProgressObserver obs, Set<Resource> unpacked)
+            throws InterruptedException {
         List<Resource> rsrcs = getActiveResources();
 
         // remove resources that we don't want to unpack
-        for (Iterator<Resource> it = rsrcs.iterator(); it.hasNext(); ) {
+        for (Iterator<Resource> it = rsrcs.iterator(); it.hasNext();) {
             Resource rsrc = it.next();
             if (!rsrc.shouldUnpack() || unpacked.contains(rsrc)) {
                 it.remove();
@@ -1372,8 +1342,7 @@ public class Application
     /**
      * Clears all validation marker files.
      */
-    public void clearValidationMarkers ()
-    {
+    public void clearValidationMarkers() {
         clearValidationMarkers(getAllActiveResources().iterator());
     }
 
@@ -1381,25 +1350,21 @@ public class Application
      * Returns the version number for the application.  Should only be called after successful
      * return of verifyMetadata.
      */
-    public long getVersion ()
-    {
+    public long getVersion() {
         return _version;
     }
 
     /**
      * Creates a versioned application base URL for the specified version.
      */
-    protected URL createVAppBase (long version)
-        throws MalformedURLException
-    {
+    protected URL createVAppBase(long version) throws MalformedURLException {
         return new URL(_appbase.replace("%VERSION%", "" + version));
     }
 
     /**
      * Clears all validation marker files for the resources in the supplied iterator.
      */
-    protected void clearValidationMarkers (Iterator<Resource> iter)
-    {
+    protected void clearValidationMarkers(Iterator<Resource> iter) {
         while (iter.hasNext()) {
             iter.next().clearMarker();
         }
@@ -1408,9 +1373,7 @@ public class Application
     /**
      * Downloads a new copy of CONFIG_FILE.
      */
-    protected void downloadConfigFile ()
-        throws IOException
-    {
+    protected void downloadConfigFile() throws IOException {
         downloadControlFile(CONFIG_FILE, false);
     }
 
@@ -1418,8 +1381,7 @@ public class Application
      * @return true if gettingdown.lock was unlocked, already locked by this application or if
      * we're not locking at all.
      */
-    public synchronized boolean lockForUpdates ()
-    {
+    public synchronized boolean lockForUpdates() {
         if (_lock != null && _lock.isValid()) {
             return true;
         }
@@ -1445,8 +1407,7 @@ public class Application
     /**
      * Release gettingdown.lock
      */
-    public synchronized void releaseLock ()
-    {
+    public synchronized void releaseLock() {
         if (_lock != null) {
             log.info("Releasing lock");
             try {
@@ -1468,9 +1429,7 @@ public class Application
      * Downloads a copy of Digest.DIGEST_FILE and validates its signature.
      * @throws IOException
      */
-    protected void downloadDigestFile ()
-        throws IOException
-    {
+    protected void downloadDigestFile() throws IOException {
         downloadControlFile(Digest.DIGEST_FILE, true);
     }
 
@@ -1486,9 +1445,7 @@ public class Application
      *
      * <p> TODO: Switch to PKCS #7 or CMS.
      */
-    protected void downloadControlFile (String path, boolean validateSignature)
-        throws IOException
-    {
+    protected void downloadControlFile(String path, boolean validateSignature) throws IOException {
         File target = downloadFile(path);
 
         if (validateSignature) {
@@ -1559,9 +1516,7 @@ public class Application
      * Download a path to a temporary file, returning a {@link File} instance with the path
      * contents.
      */
-    protected File downloadFile (String path)
-        throws IOException
-    {
+    protected File downloadFile(String path) throws IOException {
         File target = getLocalPath(path + "_new");
 
         URL targetURL = null;
@@ -1603,16 +1558,13 @@ public class Application
     }
 
     /** Helper function for creating {@link Resource} instances. */
-    protected Resource createResource (String path, boolean unpack)
-        throws MalformedURLException
-    {
+    protected Resource createResource(String path, boolean unpack) throws MalformedURLException {
         return new Resource(path, getRemoteURL(path), getLocalPath(path), unpack);
     }
 
     /** Used to parse resources with the specified name. */
-    protected void parseResources (Map<String,Object> cdata, String name, boolean unpack,
-                                   List<Resource> list)
-    {
+    protected void parseResources(Map<String, Object> cdata, String name, boolean unpack,
+            List<Resource> list) {
         String[] rsrcs = ConfigUtil.getMultiValue(cdata, name);
         if (rsrcs == null) {
             return;
@@ -1627,15 +1579,14 @@ public class Application
     }
 
     /** Used to parse rectangle specifications from the config file. */
-    protected Rectangle parseRect (Map<String,Object> cdata, String name, Rectangle def)
-    {
-        String value = (String)cdata.get(name);
+    protected Rectangle parseRect(Map<String, Object> cdata, String name, Rectangle def) {
+        String value = (String) cdata.get(name);
         Rectangle rect = parseRect(name, value);
-        return (rect == null) ? def : rect;
+        return rect == null ? def : rect;
     }
 
     /** Helper function to add all values in {@code values} (if non-null) to {@code target}. */
-    protected static void addAll (String[] values, List<String> target) {
+    protected static void addAll(String[] values, List<String> target) {
         if (values != null) {
             for (String value : values) {
                 target.add(value);
@@ -1646,8 +1597,7 @@ public class Application
     /**
      * Make an immutable List from the specified int array.
      */
-    public static List<Integer> intsToList (int[] values)
-    {
+    public static List<Integer> intsToList(int[] values) {
         List<Integer> list = new ArrayList<Integer>(values.length);
         for (int val : values) {
             list.add(val);
@@ -1659,8 +1609,7 @@ public class Application
      * Takes a comma-separated String of four integers and returns a rectangle using those ints as
      * the its x, y, width, and height.
      */
-    public static Rectangle parseRect (String name, String value)
-    {
+    public static Rectangle parseRect(String name, String value) {
         if (!StringUtil.isBlank(value)) {
             int[] v = StringUtil.parseIntArray(value);
             if (v != null && v.length == 4) {
@@ -1672,19 +1621,17 @@ public class Application
     }
 
     /** Used to parse color specifications from the config file. */
-    protected Color parseColor (Map<String, Object> cdata, String name, Color def)
-    {
-        String value = (String)cdata.get(name);
+    protected Color parseColor(Map<String, Object> cdata, String name, Color def) {
+        String value = (String) cdata.get(name);
         Color color = parseColor(value);
-        return (color == null) ? def : color;
+        return color == null ? def : color;
     }
 
     /**
      * Parses the given hex color value (e.g. FFFFF) and returns a Color object with that value. If
      * the given value is null of not a valid hexadecimal number, this will return null.
      */
-    public static Color parseColor (String hexValue)
-    {
+    public static Color parseColor(String hexValue) {
         if (!StringUtil.isBlank(hexValue)) {
             try {
                 return new Color(Integer.parseInt(hexValue, 16));
@@ -1696,28 +1643,25 @@ public class Application
     }
 
     /** Parses a list of strings from the config file. */
-    protected String[] parseList (Map<String, Object> cdata, String name)
-    {
-        String value = (String)cdata.get(name);
-        return (value == null) ? ArrayUtil.EMPTY_STRING : StringUtil.parseStringArray(value);
+    protected String[] parseList(Map<String, Object> cdata, String name) {
+        String value = (String) cdata.get(name);
+        return value == null ? ArrayUtil.EMPTY_STRING : StringUtil.parseStringArray(value);
     }
 
     /**
      * Parses a URL from the config file, checking first for a localized version.
      */
-    protected String parseUrl (Map<String, Object> cdata, String name, String def)
-    {
-        String value = (String)cdata.get(name + "." + Locale.getDefault().getLanguage());
+    protected String parseUrl(Map<String, Object> cdata, String name, String def) {
+        String value = (String) cdata.get(name + "." + Locale.getDefault().getLanguage());
         if (!StringUtil.isBlank(value)) {
             return value;
         }
-        value = (String)cdata.get(name);
+        value = (String) cdata.get(name);
         return StringUtil.isBlank(value) ? def : value;
     }
 
     /** Possibly generates and returns a google analytics tracking cookie. */
-    protected String getGATrackingCode ()
-    {
+    protected String getGATrackingCode() {
         if (_trackingGAHash == null) {
             return "";
         }
@@ -1742,8 +1686,7 @@ public class Application
     /**
      * If appbase_domain property is set, replace the domain on the provided string.
      */
-    protected String replaceDomain (String appbase)
-    {
+    protected String replaceDomain(String appbase) {
         String appbaseDomain = SysProps.appbaseDomain();
         if (appbaseDomain != null) {
             Matcher m = Pattern.compile("(http://[^/]+)(.*)").matcher(appbase);
@@ -1755,8 +1698,7 @@ public class Application
     /**
      * Encodes a path for use in a URL.
      */
-    protected static String encodePath (String path)
-    {
+    protected static String encodePath(String path) {
         // URLEncoder is too fancy for paths, we want to keep /
         return path.replace(" ", "%20");
     }
@@ -1765,8 +1707,7 @@ public class Application
      * Parses and returns a long. {@code value} must be non-null.
      * @throws IOException on malformed value.
      */
-    protected static long parseLong (String value, String errkey) throws IOException
-    {
+    protected static long parseLong(String value, String errkey) throws IOException {
         try {
             return Long.parseLong(value);
         } catch (Exception e) {
@@ -1809,8 +1750,8 @@ public class Application
     protected List<Resource> _codes = new ArrayList<Resource>();
     protected List<Resource> _resources = new ArrayList<Resource>();
 
-    protected Map<String,AuxGroup> _auxgroups = new HashMap<String,AuxGroup>();
-    protected Map<String,Boolean> _auxactive = new HashMap<String,Boolean>();
+    protected Map<String, AuxGroup> _auxgroups = new HashMap<String, AuxGroup>();
+    protected Map<String, Boolean> _auxactive = new HashMap<String, Boolean>();
 
     protected List<String> _jvmargs = new ArrayList<String>();
     protected List<String> _appargs = new ArrayList<String>();

--- a/src/main/java/com/threerings/getdown/data/Application.java
+++ b/src/main/java/com/threerings/getdown/data/Application.java
@@ -5,9 +5,21 @@
 
 package com.threerings.getdown.data;
 
+import static com.threerings.getdown.Log.log;
+
 import java.awt.Color;
 import java.awt.Rectangle;
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.PrintStream;
+import java.io.RandomAccessFile;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -16,13 +28,29 @@ import java.net.URLConnection;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
 import java.nio.channels.OverlappingFileLockException;
-import java.security.*;
+import java.security.AllPermission;
+import java.security.CodeSource;
+import java.security.GeneralSecurityException;
+import java.security.PermissionCollection;
+import java.security.Permissions;
+import java.security.Signature;
 import java.security.cert.Certificate;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import javax.swing.JApplet;
+
+import org.apache.commons.codec.binary.Base64;
 
 import com.samskivert.io.StreamUtil;
 import com.samskivert.text.MessageUtil;
@@ -30,13 +58,14 @@ import com.samskivert.util.ArrayUtil;
 import com.samskivert.util.RandomUtil;
 import com.samskivert.util.RunAnywhere;
 import com.samskivert.util.StringUtil;
-
-import org.apache.commons.codec.binary.Base64;
-
 import com.threerings.getdown.launcher.RotatingBackgrounds;
-import com.threerings.getdown.util.*;
-
-import static com.threerings.getdown.Log.log;
+import com.threerings.getdown.util.ConfigUtil;
+import com.threerings.getdown.util.ConnectionUtil;
+import com.threerings.getdown.util.FileUtil;
+import com.threerings.getdown.util.LaunchUtil;
+import com.threerings.getdown.util.ProgressAggregator;
+import com.threerings.getdown.util.ProgressObserver;
+import com.threerings.getdown.util.VersionUtil;
 
 /**
  * Parses and provide access to the information contained in the <code>getdown.txt</code>

--- a/src/main/java/com/threerings/getdown/data/Digest.java
+++ b/src/main/java/com/threerings/getdown/data/Digest.java
@@ -5,26 +5,23 @@
 
 package com.threerings.getdown.data;
 
+import static com.threerings.getdown.Log.log;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
-
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-
 import java.util.HashMap;
 import java.util.List;
 
 import com.samskivert.io.StreamUtil;
 import com.samskivert.text.MessageUtil;
 import com.samskivert.util.StringUtil;
-
 import com.threerings.getdown.util.ConfigUtil;
 import com.threerings.getdown.util.ProgressObserver;
-
-import static com.threerings.getdown.Log.log;
 
 /**
  * Manages the <code>digest.txt</code> file and the computing and processing of MD5 digests for an

--- a/src/main/java/com/threerings/getdown/data/Digest.java
+++ b/src/main/java/com/threerings/getdown/data/Digest.java
@@ -24,10 +24,13 @@ import com.threerings.getdown.util.ConfigUtil;
 import com.threerings.getdown.util.ProgressObserver;
 
 /**
- * Manages the <code>digest.txt</code> file and the computing and processing of MD5 digests for an
+ * Manages the {@code digest.txt} file and the computing and processing of MD5 digests for an
  * application.
  */
 public class Digest {
+    protected HashMap<String, String> _digests = new HashMap<String, String>();
+    protected String _metaDigest = "";
+
     /** The name of our MD5 digest file. */
     public static final String DIGEST_FILE = "digest.txt";
 
@@ -135,7 +138,4 @@ public class Digest {
     protected static void note(StringBuilder data, String path, String digest) {
         data.append(path).append(" = ").append(digest).append("\n");
     }
-
-    protected HashMap<String, String> _digests = new HashMap<String, String>();
-    protected String _metaDigest = "";
 }

--- a/src/main/java/com/threerings/getdown/data/Digest.java
+++ b/src/main/java/com/threerings/getdown/data/Digest.java
@@ -27,8 +27,7 @@ import com.threerings.getdown.util.ProgressObserver;
  * Manages the <code>digest.txt</code> file and the computing and processing of MD5 digests for an
  * application.
  */
-public class Digest
-{
+public class Digest {
     /** The name of our MD5 digest file. */
     public static final String DIGEST_FILE = "digest.txt";
 
@@ -36,9 +35,7 @@ public class Digest
      * Creates a digest instance which will parse and validate the <code>digest.txt</code> in the
      * supplied application directory.
      */
-    public Digest (File appdir)
-        throws IOException
-    {
+    public Digest(File appdir) throws IOException {
         // parse and validate our digest file contents
         StringBuilder data = new StringBuilder();
         File dfile = new File(appdir, DIGEST_FILE);
@@ -64,8 +61,7 @@ public class Digest
     /**
      * Returns the digest for the digest file.
      */
-    public String getMetaDigest ()
-    {
+    public String getMetaDigest() {
         return _metaDigest;
     }
 
@@ -76,8 +72,7 @@ public class Digest
      * @return true if the resource is valid, false if it failed the digest check or if an I/O
      * error was encountered during the validation process.
      */
-    public boolean validateResource (Resource resource, ProgressObserver obs)
-    {
+    public boolean validateResource(Resource resource, ProgressObserver obs) {
         try {
             String cmd5 = resource.computeDigest(getMessageDigest(), obs);
             String emd5 = _digests.get(resource.getPath());
@@ -95,9 +90,7 @@ public class Digest
     /**
      * Creates a digest file at the specified location using the supplied list of resources.
      */
-    public static void createDigest (List<Resource> resources, File output)
-        throws IOException
-    {
+    public static void createDigest(List<Resource> resources, File output) throws IOException {
         MessageDigest md = getMessageDigest();
         StringBuilder data = new StringBuilder();
         PrintWriter pout = null;
@@ -130,8 +123,7 @@ public class Digest
     /**
      * Obtains an appropriate message digest instance for use by the Getdown system.
      */
-    public static MessageDigest getMessageDigest ()
-    {
+    public static MessageDigest getMessageDigest() {
         try {
             return MessageDigest.getInstance("MD5");
         } catch (NoSuchAlgorithmException nsae) {
@@ -140,8 +132,7 @@ public class Digest
     }
 
     /** Used by {@link #createDigest} and {@link Digest}. */
-    protected static void note (StringBuilder data, String path, String digest)
-    {
+    protected static void note(StringBuilder data, String path, String digest) {
         data.append(path).append(" = ").append(digest).append("\n");
     }
 

--- a/src/main/java/com/threerings/getdown/data/Properties.java
+++ b/src/main/java/com/threerings/getdown/data/Properties.java
@@ -8,12 +8,13 @@ package com.threerings.getdown.data;
 /**
  * System property constants associated with Getdown.
  */
-public class Properties
-{
+public class Properties {
     /** This property will be set to "true" on the application when it is being run by getdown. */
     public static final String GETDOWN = "com.threerings.getdown";
 
-    /** If accepting connections from the launched application, this property
-     * will be set to the connection server port. */
+    /**
+     * If accepting connections from the launched application, this property will be set to the
+     * connection server port.
+     */
     public static final String CONNECT_PORT = "com.threerings.getdown.connectPort";
 }

--- a/src/main/java/com/threerings/getdown/data/Resource.java
+++ b/src/main/java/com/threerings/getdown/data/Resource.java
@@ -5,7 +5,12 @@
 
 package com.threerings.getdown.data;
 
-import java.io.*;
+import static com.threerings.getdown.Log.log;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
 import java.security.MessageDigest;
 import java.util.Collections;
@@ -13,15 +18,11 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
-import java.util.jar.JarInputStream;
 
 import com.samskivert.io.StreamUtil;
 import com.samskivert.util.StringUtil;
-
 import com.threerings.getdown.util.FileUtil;
 import com.threerings.getdown.util.ProgressObserver;
-
-import static com.threerings.getdown.Log.log;
 
 /**
  * Models a single file resource used by an {@link Application}.

--- a/src/main/java/com/threerings/getdown/data/Resource.java
+++ b/src/main/java/com/threerings/getdown/data/Resource.java
@@ -27,13 +27,11 @@ import com.threerings.getdown.util.ProgressObserver;
 /**
  * Models a single file resource used by an {@link Application}.
  */
-public class Resource
-{
+public class Resource {
     /**
      * Creates a resource with the supplied remote URL and local path.
      */
-    public Resource (String path, URL remote, File local, boolean unpack)
-    {
+    public Resource(String path, URL remote, File local, boolean unpack) {
         _path = path;
         _remote = remote;
         _local = local;
@@ -55,40 +53,35 @@ public class Resource
     /**
      * Returns the path associated with this resource.
      */
-    public String getPath ()
-    {
+    public String getPath() {
         return _path;
     }
 
     /**
      * Returns the local location of this resource.
      */
-    public File getLocal ()
-    {
+    public File getLocal() {
         return _local;
     }
 
     /**
      *  Returns the location of the unpacked resource.
      */
-    public File getUnpacked ()
-    {
+    public File getUnpacked() {
         return _unpacked;
     }
 
     /**
      *  Returns the final target of this resource, whether it has been unpacked or not.
      */
-    public File getFinalTarget ()
-    {
+    public File getFinalTarget() {
         return shouldUnpack() ? getUnpacked() : getLocal();
     }
 
     /**
      * Returns the remote location of this resource.
      */
-    public URL getRemote ()
-    {
+    public URL getRemote() {
         return _remote;
     }
 
@@ -96,8 +89,7 @@ public class Resource
      * Returns true if this resource should be unpacked as a part of the
      * validation process.
      */
-    public boolean shouldUnpack ()
-    {
+    public boolean shouldUnpack() {
         return _unpack;
     }
 
@@ -105,9 +97,7 @@ public class Resource
      * Computes the MD5 hash of this resource's underlying file.
      * <em>Note:</em> This is both CPU and I/O intensive.
      */
-    public String computeDigest (MessageDigest md, ProgressObserver obs)
-        throws IOException
-    {
+    public String computeDigest(MessageDigest md, ProgressObserver obs) throws IOException {
         return computeDigest(_local, md, obs);
     }
 
@@ -115,8 +105,7 @@ public class Resource
      * Returns true if this resource has an associated "validated" marker
      * file.
      */
-    public boolean isMarkedValid ()
-    {
+    public boolean isMarkedValid() {
         if (!_local.exists()) {
             clearMarker();
             return false;
@@ -131,17 +120,14 @@ public class Resource
      *
      * @throws IOException if we fail to create the marker file.
      */
-    public void markAsValid ()
-        throws IOException
-    {
+    public void markAsValid() throws IOException {
         _marker.createNewFile();
     }
 
     /**
      * Removes any "validated" marker file associated with this resource.
      */
-    public void clearMarker ()
-    {
+    public void clearMarker() {
         if (_marker.exists() && !_marker.delete()) {
             log.warning("Failed to erase marker file '" + _marker + "'.");
         }
@@ -151,8 +137,7 @@ public class Resource
      * Unpacks this resource file into the directory that contains it. Returns
      * false if an error occurs while unpacking it.
      */
-    public boolean unpack ()
-    {
+    public boolean unpack() {
         // sanity check
         if (!_isJar && !_isPacked200Jar) {
             log.warning("Requested to unpack non-jar file '" + _local + "'.");
@@ -161,7 +146,7 @@ public class Resource
         try {
             if (_isJar) {
                 return FileUtil.unpackJar(new JarFile(_local), _unpacked);
-            } else{
+            } else {
                 return FileUtil.unpackPacked200Jar(_local, _unpacked);
             }
         } catch (IOException ioe) {
@@ -174,39 +159,37 @@ public class Resource
      * Wipes this resource file along with any "validated" marker file that may be associated with
      * it.
      */
-    public void erase ()
-    {
+    public void erase() {
         clearMarker();
         if (_local.exists() && !_local.delete()) {
             log.warning("Failed to erase resource '" + _local + "'.");
         }
     }
 
-    @Override public boolean equals (Object other)
-    {
+    @Override
+    public boolean equals(Object other) {
         if (other instanceof Resource) {
-            return _path.equals(((Resource)other)._path);
+            return _path.equals(((Resource) other)._path);
         } else {
             return false;
         }
     }
 
-    @Override public int hashCode ()
-    {
+    @Override
+    public int hashCode() {
         return _path.hashCode();
     }
 
-    @Override public String toString ()
-    {
+    @Override
+    public String toString() {
         return _path;
     }
 
     /**
      * Computes the MD5 hash of the supplied file.
      */
-    public static String computeDigest (File target, MessageDigest md, ProgressObserver obs)
-        throws IOException
-    {
+    public static String computeDigest(File target, MessageDigest md, ProgressObserver obs)
+            throws IOException {
         md.reset();
         byte[] buffer = new byte[DIGEST_BUFFER_SIZE];
         int read;
@@ -216,16 +199,16 @@ public class Resource
 
         // if this is a jar, we need to compute the digest in a "timestamp and file order" agnostic
         // manner to properly correlate jardiff patched jars with their unpatched originals
-        if (isJar || isPacked200Jar){
+        if (isJar || isPacked200Jar) {
             File tmpJarFile = null;
             JarFile jar = null;
             try {
                 // if this is a compressed jar file, uncompress it to compute the jar file digest
-                if (isPacked200Jar){
+                if (isPacked200Jar) {
                     tmpJarFile = new File(target.getPath() + ".tmp");
                     FileUtil.unpackPacked200Jar(target, tmpJarFile);
                     jar = new JarFile(tmpJarFile);
-                } else{
+                } else {
                     jar = new JarFile(target);
                 }
 
@@ -284,20 +267,17 @@ public class Resource
     }
 
     /** Helper function to simplify the process of reporting progress. */
-    protected static void updateProgress (ProgressObserver obs, long pos, long total)
-    {
+    protected static void updateProgress(ProgressObserver obs, long pos, long total) {
         if (obs != null) {
-            obs.progress((int)(100 * pos / total));
+            obs.progress((int) (100 * pos / total));
         }
     }
 
-    protected static boolean isJar (String path)
-    {
+    protected static boolean isJar(String path) {
         return path.endsWith(".jar");
     }
 
-    protected static boolean isPacked200Jar (String path)
-    {
+    protected static boolean isPacked200Jar(String path) {
         return path.endsWith(".jar.pack") || path.endsWith(".jar.pack.gz");
     }
 
@@ -308,7 +288,8 @@ public class Resource
 
     /** Used to sort the entries in a jar file. */
     protected static final Comparator<JarEntry> ENTRY_COMP = new Comparator<JarEntry>() {
-        @Override public int compare (JarEntry e1, JarEntry e2) {
+        @Override
+        public int compare(JarEntry e1, JarEntry e2) {
             return e1.getName().compareTo(e2.getName());
         }
     };

--- a/src/main/java/com/threerings/getdown/data/Resource.java
+++ b/src/main/java/com/threerings/getdown/data/Resource.java
@@ -28,6 +28,21 @@ import com.threerings.getdown.util.ProgressObserver;
  * Models a single file resource used by an {@link Application}.
  */
 public class Resource {
+    protected static final int DIGEST_BUFFER_SIZE = 5 * 1025;
+
+    protected String _path;
+    protected URL _remote;
+    protected File _local, _marker, _unpacked;
+    protected boolean _unpack, _isJar, _isPacked200Jar;
+
+    /** Used to sort the entries in a jar file. */
+    protected static final Comparator<JarEntry> ENTRY_COMP = new Comparator<JarEntry>() {
+        @Override
+        public int compare(JarEntry e1, JarEntry e2) {
+            return e1.getName().compareTo(e2.getName());
+        }
+    };
+
     /**
      * Creates a resource with the supplied remote URL and local path.
      */
@@ -43,7 +58,7 @@ public class Resource {
         _isPacked200Jar = isPacked200Jar(lpath);
         if (_unpack && _isJar) {
             _unpacked = _local.getParentFile();
-        } else if(_unpack && _isPacked200Jar) {
+        } else if (_unpack && _isPacked200Jar) {
             String dotJar = ".jar", lname = _local.getName();
             String uname = lname.substring(0, lname.lastIndexOf(dotJar) + dotJar.length());
             _unpacked = new File(_local.getParent(), uname);
@@ -280,19 +295,4 @@ public class Resource {
     protected static boolean isPacked200Jar(String path) {
         return path.endsWith(".jar.pack") || path.endsWith(".jar.pack.gz");
     }
-
-    protected String _path;
-    protected URL _remote;
-    protected File _local, _marker, _unpacked;
-    protected boolean _unpack, _isJar, _isPacked200Jar;
-
-    /** Used to sort the entries in a jar file. */
-    protected static final Comparator<JarEntry> ENTRY_COMP = new Comparator<JarEntry>() {
-        @Override
-        public int compare(JarEntry e1, JarEntry e2) {
-            return e1.getName().compareTo(e2.getName());
-        }
-    };
-
-    protected static final int DIGEST_BUFFER_SIZE = 5 * 1025;
 }

--- a/src/main/java/com/threerings/getdown/data/SysProps.java
+++ b/src/main/java/com/threerings/getdown/data/SysProps.java
@@ -13,56 +13,55 @@ import com.threerings.getdown.util.VersionUtil;
  * accessor so that it's easy to see all of the secret system property arguments that Getdown makes
  * use of.
  */
-public class SysProps
-{
+public class SysProps {
     /** Configures the appdir (in lieu of passing it in argv). Usage: {@code -Dappdir=foo}. */
-    public static String appDir () {
+    public static String appDir() {
         return System.getProperty("appdir");
     }
 
     /** Configures the appid (in lieu of passing it in argv). Usage: {@code -Dappid=foo}. */
-    public static String appId () {
+    public static String appId() {
         return System.getProperty("appid");
     }
 
     /** Configures the appbase (in lieu of providing a skeleton getdown.txt, and as a last resort
       * fallback). Usage: {@code -Dappbase=someurl}. */
-    public static String appBase () {
+    public static String appBase() {
         return System.getProperty("appbase");
     }
 
     /** If true, disables redirection of logging into {@code launcher.log}.
       * Usage: {@code -Dno_log_redir}. */
-    public static boolean noLogRedir () {
+    public static boolean noLogRedir() {
         return System.getProperty("no_log_redir") != null;
     }
 
     /** Overrides the domain on {@code appbase}. Usage: {@code -Dappbase_domain=foo}. */
-    public static String appbaseDomain () {
+    public static String appbaseDomain() {
         return System.getProperty("appbase_domain");
     }
 
     /** If true, Getdown installs the app without ever bringing up a UI, except in the event of an
       * error. NOTE: it does not launch the app. See {@link #launchInSilent}.
       * Usage: {@code -Dsilent}. */
-    public static boolean silent () {
+    public static boolean silent() {
         return System.getProperty("silent") != null;
     }
 
     /** If true, Getdown installs the app without ever bringing up a UI and then launches it.
       * Usage: {@code -Dsilent=launch}. */
-    public static boolean launchInSilent () {
+    public static boolean launchInSilent() {
         return "launch".equals(System.getProperty("silent"));
     }
 
     /** Specifies the a delay (in minutes) to wait before starting the update and install process.
       * Usage: {@code -Ddelay=N}. */
-    public static int startDelay () {
+    public static int startDelay() {
         return Integer.getInteger("delay", 0);
     }
 
     /** If true, Getdown will not unpack {@code uresource} jars. Usage: {@code -Dno_unpack}. */
-    public static boolean noUnpack () {
+    public static boolean noUnpack() {
         return Boolean.getBoolean("no_unpack");
     }
 
@@ -70,7 +69,7 @@ public class SysProps
       * false (the default), Getdown will fork a new VM. Note that reusing the same VM prevents
       * Getdown from configuring some launch-time-only VM parameters (like -mxN etc.).
       * Usage: {@code -Ddirect}. */
-    public static boolean direct () {
+    public static boolean direct() {
         return Boolean.getBoolean("direct");
     }
 
@@ -78,7 +77,7 @@ public class SysProps
       * the server. This is chiefly useful when you are running in versionless mode and want Getdown
       * to more quickly timeout its startup update check if the server with which it is
       * communicating is not available. Usage: {@code -Dconnect_timeout=N}. */
-    public static int connectTimeout () {
+    public static int connectTimeout() {
         return Integer.getInteger("connect_timeout", 0);
     }
 
@@ -105,14 +104,18 @@ public class SysProps
       * @throws IllegalArgumentException if no system named {@code propName} exists, or if
       * {@code propRegex} does not match the returned version string.
       */
-    public static long parseJavaVersion (String propName, String propRegex) {
+    public static long parseJavaVersion(String propName, String propRegex) {
         String verstr = System.getProperty(propName);
-        if (verstr == null) throw new IllegalArgumentException(
-            "No system property '" + propName + "'.");
+        if (verstr == null) {
+            throw new IllegalArgumentException(
+                "No system property '" + propName + "'.");
+        }
 
         long vers = VersionUtil.parseJavaVersion(propRegex, verstr);
-        if (vers == 0L) throw new IllegalArgumentException(
-            "Regexp '" + propRegex + "' does not match '" + verstr + "' (from " + propName + ")");
+        if (vers == 0L) {
+            throw new IllegalArgumentException(
+                "Regexp '" + propRegex + "' does not match '" + verstr + "' (from " + propName + ")");
+        }
         return vers;
     }
 }

--- a/src/main/java/com/threerings/getdown/launcher/AbortPanel.java
+++ b/src/main/java/com/threerings/getdown/launcher/AbortPanel.java
@@ -28,6 +28,9 @@ import com.samskivert.text.MessageUtil;
  * Displays a confirmation that the user wants to abort installation.
  */
 public class AbortPanel extends JFrame implements ActionListener {
+    protected Getdown _getdown;
+    protected ResourceBundle _msgs;
+
     public AbortPanel(Getdown getdown, ResourceBundle msgs) {
         _getdown = getdown;
         _msgs = msgs;
@@ -86,7 +89,4 @@ public class AbortPanel extends JFrame implements ActionListener {
             return key;
         }
     }
-
-    protected Getdown _getdown;
-    protected ResourceBundle _msgs;
 }

--- a/src/main/java/com/threerings/getdown/launcher/AbortPanel.java
+++ b/src/main/java/com/threerings/getdown/launcher/AbortPanel.java
@@ -5,10 +5,11 @@
 
 package com.threerings.getdown.launcher;
 
+import static com.threerings.getdown.Log.log;
+
 import java.awt.Dimension;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
 
@@ -23,8 +24,6 @@ import com.samskivert.swing.Spacer;
 import com.samskivert.swing.VGroupLayout;
 import com.samskivert.text.MessageUtil;
 
-import static com.threerings.getdown.Log.log;
-
 /**
  * Displays a confirmation that the user wants to abort installation.
  */
@@ -35,7 +34,7 @@ public class AbortPanel extends JFrame
     {
         _getdown = getdown;
         _msgs = msgs;
- 
+
         setLayout(new VGroupLayout());
         setResizable(false);
         setTitle(get("m.abort_title"));

--- a/src/main/java/com/threerings/getdown/launcher/AbortPanel.java
+++ b/src/main/java/com/threerings/getdown/launcher/AbortPanel.java
@@ -27,11 +27,8 @@ import com.samskivert.text.MessageUtil;
 /**
  * Displays a confirmation that the user wants to abort installation.
  */
-public class AbortPanel extends JFrame
-    implements ActionListener
-{
-    public AbortPanel (Getdown getdown, ResourceBundle msgs)
-    {
+public class AbortPanel extends JFrame implements ActionListener {
+    public AbortPanel(Getdown getdown, ResourceBundle msgs) {
         _getdown = getdown;
         _msgs = msgs;
 
@@ -56,10 +53,8 @@ public class AbortPanel extends JFrame
         add(row);
     }
 
-    // documentation inherited
     @Override
-    public Dimension getPreferredSize ()
-    {
+    public Dimension getPreferredSize() {
         // this is annoyingly hardcoded, but we can't just force the width
         // or the JLabel will claim a bogus height thinking it can lay its
         // text out all on one line which will booch the whole UI's
@@ -67,9 +62,8 @@ public class AbortPanel extends JFrame
         return new Dimension(300, 200);
     }
 
-    // documentation inherited from interface
-    public void actionPerformed (ActionEvent e)
-    {
+    @Override
+    public void actionPerformed(ActionEvent e) {
         String cmd = e.getActionCommand();
         if (cmd.equals("ok")) {
             System.exit(0);
@@ -79,8 +73,7 @@ public class AbortPanel extends JFrame
     }
 
     /** Used to look up localized messages. */
-    protected String get (String key)
-    {
+    protected String get(String key) {
         // if this string is tainted, we don't translate it, instead we
         // simply remove the taint character and return it to the caller
         if (MessageUtil.isTainted(key)) {

--- a/src/main/java/com/threerings/getdown/launcher/Getdown.java
+++ b/src/main/java/com/threerings/getdown/launcher/Getdown.java
@@ -74,6 +74,41 @@ import ca.beq.util.win32.registry.RootKey;
  * Manages the main control for the Getdown application updater and deployment system.
  */
 public abstract class Getdown extends Thread implements Application.StatusDisplay, ImageLoader {
+    protected static final int MAX_LOOPS = 5;
+    protected static final long MIN_EXIST_TIME = 5000L;
+    protected static final long FALLBACK_CHECK_TIME = 1000L;
+    protected static final long PLAY_AGAIN_TIME = 3000L;
+    protected static final String PROXY_REGISTRY =
+        "Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings";
+
+    protected Application _app;
+    protected Application.UpdateInterface _ifc = new Application.UpdateInterface();
+
+    protected ResourceBundle _msgs;
+    protected Container _container;
+    protected JLayeredPane _layers;
+    protected StatusPanel _status;
+    protected JButton _patchNotes;
+    protected JButton _playAgain;
+    protected AbortPanel _abort;
+    protected RotatingBackgrounds _background;
+
+    protected boolean _dead;
+    protected boolean _silent;
+    protected boolean _launchInSilent;
+    protected long _startup;
+
+    protected boolean _enableTracking = true;
+    protected int _reportedProgress = 0;
+
+    /** Number of minutes to wait after startup before beginning any real heavy lifting. */
+    protected int _delay;
+
+    protected int _stepMaxPercent;
+    protected int _stepMinPercent;
+    protected int _lastGlobalPercent;
+    protected int _uiDisplayPercent;
+
     public static void main(String[] args) {
         // legacy support
         GetdownApp.main(args);
@@ -1175,39 +1210,4 @@ public abstract class Getdown extends Thread implements Application.StatusDispla
             setStatusAsync(null, stepToGlobalPercent(percent), -1L, false);
         }
     };
-
-    protected Application _app;
-    protected Application.UpdateInterface _ifc = new Application.UpdateInterface();
-
-    protected ResourceBundle _msgs;
-    protected Container _container;
-    protected JLayeredPane _layers;
-    protected StatusPanel _status;
-    protected JButton _patchNotes;
-    protected JButton _playAgain;
-    protected AbortPanel _abort;
-    protected RotatingBackgrounds _background;
-
-    protected boolean _dead;
-    protected boolean _silent;
-    protected boolean _launchInSilent;
-    protected long _startup;
-
-    protected boolean _enableTracking = true;
-    protected int _reportedProgress = 0;
-
-    /** Number of minutes to wait after startup before beginning any real heavy lifting. */
-    protected int _delay;
-
-    protected int _stepMaxPercent;
-    protected int _stepMinPercent;
-    protected int _lastGlobalPercent;
-    protected int _uiDisplayPercent;
-
-    protected static final int MAX_LOOPS = 5;
-    protected static final long MIN_EXIST_TIME = 5000L;
-    protected static final long FALLBACK_CHECK_TIME = 1000L;
-    protected static final long PLAY_AGAIN_TIME = 3000L;
-    protected static final String PROXY_REGISTRY =
-        "Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings";
 }

--- a/src/main/java/com/threerings/getdown/launcher/Getdown.java
+++ b/src/main/java/com/threerings/getdown/launcher/Getdown.java
@@ -73,23 +73,18 @@ import ca.beq.util.win32.registry.RootKey;
 /**
  * Manages the main control for the Getdown application updater and deployment system.
  */
-public abstract class Getdown extends Thread
-    implements Application.StatusDisplay, ImageLoader
-{
-    public static void main (String[] args)
-    {
+public abstract class Getdown extends Thread implements Application.StatusDisplay, ImageLoader {
+    public static void main(String[] args) {
         // legacy support
         GetdownApp.main(args);
     }
 
-    public Getdown (File appDir, String appId)
-    {
+    public Getdown(File appDir, String appId) {
         this(appDir, appId, null, null, null);
     }
 
-    public Getdown (File appDir, String appId, List<Certificate> signers,
-                    String[] jvmargs, String[] appargs)
-    {
+    public Getdown(File appDir, String appId, List<Certificate> signers, String[] jvmargs,
+            String[] appargs) {
         super("Getdown");
         try {
             // If the silent property exists, install without bringing up any gui. If it equals
@@ -112,9 +107,9 @@ public abstract class Getdown extends Thread
             if (dir.equals(".")) {
                 dir = System.getProperty("user.dir");
             }
-            String errmsg = "The directory in which this application is installed:\n" + dir +
-                "\nis invalid (" + e.getMessage() + "). If the full path to the app directory " +
-                "contains the '!' character, this will trigger this error.";
+            String errmsg = "The directory in which this application is installed:\n" + dir
+                + "\nis invalid (" + e.getMessage() + "). If the full path to the app directory "
+                + "contains the '!' character, this will trigger this error.";
             fail(errmsg);
         }
         _app = new Application(appDir, appId, signers, jvmargs, appargs);
@@ -125,8 +120,7 @@ public abstract class Getdown extends Thread
      * This is used by the applet which always needs a user interface and wants to load it as soon
      * as possible.
      */
-    public void preInit ()
-    {
+    public void preInit() {
         try {
             _ifc = _app.init(true);
             createInterfaceAsync(true);
@@ -137,8 +131,7 @@ public abstract class Getdown extends Thread
     }
 
     @Override
-    public void run ()
-    {
+    public void run() {
         // if we have no messages, just bail because we're hosed; the error message will be
         // displayed to the user already
         if (_msgs == null) {
@@ -195,8 +188,7 @@ public abstract class Getdown extends Thread
     /**
      * Configures our proxy settings (called by {@link ProxyPanel}) and fires up the launcher.
      */
-    public void configureProxy (String host, String port)
-    {
+    public void configureProxy(String host, String port) {
         log.info("User configured proxy", "host", host, "port", port);
 
         // if we're provided with valid values, create a proxy.txt file
@@ -231,8 +223,7 @@ public abstract class Getdown extends Thread
      * @return true if we should proceed with running the launcher, false if we need to wait for
      * the user to enter proxy settings.
      */
-    protected boolean detectProxy ()
-    {
+    protected boolean detectProxy() {
         // we may already have a proxy configured
         if (System.getProperty("http.proxyHost") != null) {
             return true;
@@ -245,8 +236,8 @@ public abstract class Getdown extends Thread
                 boolean enabled = false;
                 RegistryKey.initialize();
                 RegistryKey r = new RegistryKey(RootKey.HKEY_CURRENT_USER, PROXY_REGISTRY);
-                for (Iterator<?> iter = r.values(); iter.hasNext(); ) {
-                    RegistryValue value = (RegistryValue)iter.next();
+                for (Iterator<?> iter = r.values(); iter.hasNext();) {
+                    RegistryValue value = (RegistryValue) iter.next();
                     if (value.getName().equals("ProxyEnable")) {
                         enabled = value.getStringValue().equals("1");
                     }
@@ -254,7 +245,7 @@ public abstract class Getdown extends Thread
                         String strval = value.getStringValue();
                         int cidx = strval.indexOf(":");
                         if (cidx != -1) {
-                            port = strval.substring(cidx+1);
+                            port = strval.substring(cidx + 1);
                             strval = strval.substring(0, cidx);
                         }
                         host = strval;
@@ -278,7 +269,7 @@ public abstract class Getdown extends Thread
         if (pfile.exists()) {
             try {
                 Map<String, Object> pconf = ConfigUtil.parseConfig(pfile, false);
-                setProxyProperties((String)pconf.get("host"), (String)pconf.get("port"));
+                setProxyProperties((String) pconf.get("host"), (String) pconf.get("port"));
                 return true;
             } catch (IOException ioe) {
                 log.warning("Failed to read '" + pfile + "': " + ioe);
@@ -300,7 +291,7 @@ public abstract class Getdown extends Thread
             // try to make a HEAD request for this URL
             URLConnection conn = ConnectionUtil.open(rurl);
             if (conn instanceof HttpURLConnection) {
-                HttpURLConnection hcon = (HttpURLConnection)conn;
+                HttpURLConnection hcon = (HttpURLConnection) conn;
                 try {
                     hcon.setRequestMethod("HEAD");
                     hcon.connect();
@@ -336,8 +327,7 @@ public abstract class Getdown extends Thread
     /**
      * Configures the JVM proxy system properties.
      */
-    protected void setProxyProperties (String host, String port)
-    {
+    protected void setProxyProperties(String host, String port) {
         if (!StringUtil.isBlank(host)) {
             System.setProperty("http.proxyHost", host);
             System.setProperty("https.proxyHost", host);
@@ -352,8 +342,7 @@ public abstract class Getdown extends Thread
     /**
      * Does the actual application validation, update and launching business.
      */
-    protected void getdown ()
-    {
+    protected void getdown() {
         log.info("---------------- Proxy Info -----------------");
         log.info("-- Proxy Host: " + System.getProperty("http.proxyHost"));
         log.info("-- Proxy Port: " + System.getProperty("http.proxyPort"));
@@ -484,7 +473,7 @@ public abstract class Getdown extends Thread
                 try {
                     // if any of our resources have already been marked valid this is not a first
                     // time install and we don't want to enable tracking
-                    _enableTracking = (alreadyValid[0] == 0);
+                    _enableTracking = alreadyValid[0] == 0;
                     reportTrackingEvent("app_start", -1);
 
                     // redownload any that are corrupt or invalid...
@@ -526,9 +515,8 @@ public abstract class Getdown extends Thread
         }
     }
 
-    // documentation inherited from interface
-    public void updateStatus (String message)
-    {
+    @Override
+    public void updateStatus(String message) {
         setStatusAsync(message, -1, -1L, true);
     }
 
@@ -537,8 +525,8 @@ public abstract class Getdown extends Thread
      * if we can find a localized version by sticking a {@code _<language>} in front of the "." in
      * the filename.
      */
-    public BufferedImage loadImage (String path)
-    {
+    @Override
+    public BufferedImage loadImage(String path) {
         if (StringUtil.isBlank(path)) {
             return null;
         }
@@ -567,9 +555,7 @@ public abstract class Getdown extends Thread
      * Downloads and installs an Java VM bundled with the application. This is called if we are not
      * running with the necessary Java version.
      */
-    protected void updateJava ()
-        throws IOException, InterruptedException
-    {
+    protected void updateJava() throws IOException, InterruptedException {
         Resource vmjar = _app.getJavaVMResource();
         if (vmjar == null) {
             throw new IOException("m.java_download_failed");
@@ -594,8 +580,8 @@ public abstract class Getdown extends Thread
         // extension then, neither does Jar), so on Joonix we have to hackily make java_vm/bin/java
         // executable by execing chmod; a pox on their children!
         if (!RunAnywhere.isWindows()) {
-            String vmbin = LaunchUtil.LOCAL_JAVA_DIR + File.separator + "bin" +
-                File.separator + "java";
+            String vmbin = LaunchUtil.LOCAL_JAVA_DIR + File.separator + "bin"
+                + File.separator + "java";
             String cmd = "chmod a+rx " + _app.getLocalPath(vmbin);
             try {
                 log.info("Please smack a Java engineer. Running: " + cmd);
@@ -621,9 +607,7 @@ public abstract class Getdown extends Thread
     /**
      * Called if the application is determined to be of an old version.
      */
-    protected void update ()
-        throws IOException, InterruptedException
-    {
+    protected void update() throws IOException, InterruptedException {
         // first clear all validation markers
         _app.clearValidationMarkers();
 
@@ -647,7 +631,8 @@ public abstract class Getdown extends Thread
             if (!StringUtil.isBlank(_ifc.patchNotesUrl)) {
                 createInterfaceAsync(false);
                 EventQueue.invokeLater(new Runnable() {
-                    public void run () {
+                    @Override
+                    public void run() {
                         _patchNotes.setVisible(true);
                     }
                 });
@@ -694,19 +679,19 @@ public abstract class Getdown extends Thread
     /**
      * Called if the application is determined to require resource downloads.
      */
-    protected void download (List<Resource> resources)
-        throws IOException, InterruptedException
-    {
+    protected void download(List<Resource> resources) throws IOException, InterruptedException {
         // create our user interface
         createInterfaceAsync(false);
 
         // create a downloader to download our resources
         Downloader.Observer obs = new Downloader.Observer() {
-            public void resolvingDownloads () {
+            @Override
+            public void resolvingDownloads() {
                 updateStatus("m.resolving");
             }
 
-            public boolean downloadProgress (int percent, long remaining) {
+            @Override
+            public boolean downloadProgress(int percent, long remaining) {
                 // check for another getdown running at 0 and every 10% after that
                 if (_lastCheck == -1 || percent >= _lastCheck + 10) {
                     if (_delay > 0) {
@@ -730,7 +715,8 @@ public abstract class Getdown extends Thread
                 return true;
             }
 
-            public void downloadFailed (Resource rsrc, Exception e) {
+            @Override
+            public void downloadFailed(Resource rsrc, Exception e) {
                 updateStatus(MessageUtil.tcompose("m.failure", e.getMessage()));
                 log.warning("Download failed", "rsrc", rsrc, e);
             }
@@ -753,8 +739,7 @@ public abstract class Getdown extends Thread
     /**
      * Called to launch the application if everything is determined to be ready to go.
      */
-    protected void launch ()
-    {
+    protected void launch() {
         setStep(Step.LAUNCH);
         setStatusAsync("m.launching", stepToGlobalPercent(100), -1L, false);
 
@@ -810,7 +795,7 @@ public abstract class Getdown extends Thread
                     // spawn a daemon thread that will catch the early bits of stderr in case the
                     // launch fails
                     Thread t = new Thread() {
-                        @Override public void run () {
+                        @Override public void run() {
                             copyStream(stderr, System.err);
                         }
                     };
@@ -838,7 +823,7 @@ public abstract class Getdown extends Thread
                 // wait a little time before showing the button
                 Timer timer = new Timer("playAgain", true);
                 timer.schedule(new TimerTask() {
-                    @Override public void run () {
+                    @Override public void run() {
                         initPlayAgain();
                         _playAgain.setVisible(true);
                     }
@@ -856,14 +841,14 @@ public abstract class Getdown extends Thread
      *
      * @param reinit - if the interface should be reinitialized if it already exists.
      */
-    protected void createInterfaceAsync (final boolean reinit)
-    {
-        if (_silent || (_container != null && !reinit)) {
+    protected void createInterfaceAsync(final boolean reinit) {
+        if (_silent || _container != null && !reinit) {
             return;
         }
 
         EventQueue.invokeLater(new Runnable() {
-            public void run () {
+            @Override
+            public void run() {
                 if (_container == null || reinit) {
                     if (_container == null) {
                         _container = createContainer();
@@ -873,7 +858,7 @@ public abstract class Getdown extends Thread
                     _layers = new JLayeredPane();
                     _container.add(_layers, BorderLayout.CENTER);
                     _patchNotes = new JButton(new AbstractAction(_msgs.getString("m.patch_notes")) {
-                        @Override public void actionPerformed (ActionEvent event) {
+                        @Override public void actionPerformed(ActionEvent event) {
                             showDocument(_ifc.patchNotesUrl);
                         }
                     });
@@ -886,11 +871,12 @@ public abstract class Getdown extends Thread
                         _playAgain.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
                         _playAgain.setFont(StatusPanel.FONT);
                         _playAgain.addActionListener(new ActionListener() {
-                            @Override public void actionPerformed (ActionEvent event) {
+                            @Override public void actionPerformed(ActionEvent event) {
                                 _playAgain.setVisible(false);
                                 _stepMinPercent = _lastGlobalPercent = 0;
                                 EventQueue.invokeLater(new Runnable() {
-                                    public void run () {
+                                    @Override
+                                    public void run() {
                                         getdown();
                                     }
                                 });
@@ -911,8 +897,7 @@ public abstract class Getdown extends Thread
     /**
      * Initializes the interface with the current UpdateInterface and backgrounds.
      */
-    protected void initInterface ()
-    {
+    protected void initInterface() {
         RotatingBackgrounds newBackgrounds = getBackground();
         if (_background == null || newBackgrounds.getNumImages() > 0) {
             // Leave the old _background in place if there is an old one to leave in place
@@ -935,8 +920,7 @@ public abstract class Getdown extends Thread
         _stepMinPercent = _lastGlobalPercent = 0;
     }
 
-    protected void initPlayAgain ()
-    {
+    protected void initPlayAgain() {
         if (_playAgain != null) {
             Image image = loadImage(_ifc.playAgainImage);
             boolean hasImage = image != null;
@@ -958,12 +942,11 @@ public abstract class Getdown extends Thread
         }
     }
 
-    protected RotatingBackgrounds getBackground ()
-    {
+    protected RotatingBackgrounds getBackground() {
         if (_ifc.rotatingBackgrounds != null) {
             if (_ifc.backgroundImage != null) {
-                log.warning("ui.background_image and ui.rotating_background were both specified. " +
-                            "The rotating images are being used.");
+                log.warning("ui.background_image and ui.rotating_background were both specified. "
+                            + "The rotating images are being used.");
             }
             return new RotatingBackgrounds(_ifc.rotatingBackgrounds, _ifc.errorBackground,
                 Getdown.this);
@@ -974,13 +957,11 @@ public abstract class Getdown extends Thread
         }
     }
 
-    protected Image getProgressImage ()
-    {
+    protected Image getProgressImage() {
         return loadImage(_ifc.progressImage);
     }
 
-    protected void handleWindowClose ()
-    {
+    protected void handleWindowClose() {
         if (_dead) {
             exit(0);
         } else {
@@ -996,10 +977,9 @@ public abstract class Getdown extends Thread
     }
 
     /**
-     * Update the status to indicate getdown has failed for the reason in <code>message</code>.
+     * Update the status to indicate getdown has failed for the reason in {@code message}.
      */
-    protected void fail (String message)
-    {
+    protected void fail(String message) {
         _dead = true;
         setStatusAsync(message, stepToGlobalPercent(0), -1L, true);
     }
@@ -1007,8 +987,7 @@ public abstract class Getdown extends Thread
     /**
      * Set the current step, which will be used to globalize per-step percentages.
      */
-    protected void setStep (Step step)
-    {
+    protected void setStep(Step step) {
         int finalPercent = -1;
         for (Integer perc : _ifc.stepPercentages.get(step)) {
             if (perc > _stepMaxPercent) {
@@ -1028,27 +1007,26 @@ public abstract class Getdown extends Thread
     /**
      * Convert a step percentage to the global percentage.
      */
-    protected int stepToGlobalPercent (int percent)
-    {
+    protected int stepToGlobalPercent(int percent) {
         int adjustedMaxPercent =
-            ((_stepMaxPercent - _uiDisplayPercent) * 100) / (100 - _uiDisplayPercent);
+            (_stepMaxPercent - _uiDisplayPercent) * 100 / (100 - _uiDisplayPercent);
         _lastGlobalPercent = Math.max(_lastGlobalPercent,
-            _stepMinPercent + (percent * (adjustedMaxPercent - _stepMinPercent)) / 100);
+            _stepMinPercent + percent * (adjustedMaxPercent - _stepMinPercent) / 100);
         return _lastGlobalPercent;
     }
 
     /**
      * Updates the status. NOTE: this happens on the next UI tick, not immediately.
      */
-    protected void setStatusAsync (final String message, final int percent, final long remaining,
-                                   boolean createUI)
-    {
+    protected void setStatusAsync(final String message, final int percent, final long remaining,
+            boolean createUI) {
         if (_status == null && createUI) {
             createInterfaceAsync(false);
         }
 
         EventQueue.invokeLater(new Runnable() {
-            public void run () {
+            @Override
+            public void run() {
                 if (_status == null) {
                     if (message != null) {
                         log.info("Dropping status '" + message + "'.");
@@ -1067,8 +1045,7 @@ public abstract class Getdown extends Thread
         });
     }
 
-    protected void reportTrackingEvent (String event, int progress)
-    {
+    protected void reportTrackingEvent(String event, int progress) {
         if (!_enableTracking) {
             return;
 
@@ -1092,23 +1069,23 @@ public abstract class Getdown extends Thread
     /**
      * Creates the container in which our user interface will be displayed.
      */
-    protected abstract Container createContainer ();
+    protected abstract Container createContainer();
 
     /**
      * Shows the container in which our user interface will be displayed.
      */
-    protected abstract void showContainer ();
+    protected abstract void showContainer();
 
     /**
      * Disposes the container in which we have our user interface.
      */
-    protected abstract void disposeContainer ();
+    protected abstract void disposeContainer();
 
     /**
      * If this method returns true we will run the application in the same JVM, otherwise we will
      * fork off a new JVM. Some options are not supported if we do not fork off a new JVM.
      */
-    protected boolean invokeDirect ()
+    protected boolean invokeDirect()
     {
         // by default check a sysprop (which itself defaults to false); in applet mode this is
         // overridden to check the applet config
@@ -1119,7 +1096,7 @@ public abstract class Getdown extends Thread
      * Provides access to the applet that we'll pass on to our application when we're in "invoke
      * direct" mode.
      */
-    protected JApplet getApplet ()
+    protected JApplet getApplet()
     {
         return null;
     }
@@ -1127,19 +1104,18 @@ public abstract class Getdown extends Thread
     /**
      * Requests to show the document at the specified URL in a new window.
      */
-    protected abstract void showDocument (String url);
+    protected abstract void showDocument(String url);
 
     /**
      * Requests that Getdown exit. In applet mode this does nothing.
      */
-    protected abstract void exit (int exitCode);
+    protected abstract void exit(int exitCode);
 
     /**
      * Copies the supplied stream from the specified input to the specified output. Used to copy
      * our child processes stderr and stdout to our own stderr and stdout.
      */
-    protected static void copyStream (InputStream in, PrintStream out)
-    {
+    protected static void copyStream(InputStream in, PrintStream out) {
         try {
             BufferedReader reader = new BufferedReader(new InputStreamReader(in));
             String line;
@@ -1153,15 +1129,14 @@ public abstract class Getdown extends Thread
     }
 
     /** Used to fetch a progress report URL. */
-    protected class ProgressReporter extends Thread
-    {
+    protected class ProgressReporter extends Thread {
         public ProgressReporter (URL url) {
             setDaemon(true);
             _url = url;
         }
 
         @Override
-        public void run () {
+        public void run() {
             try {
                 HttpURLConnection ucon = ConnectionUtil.openHttp(_url);
 
@@ -1195,7 +1170,8 @@ public abstract class Getdown extends Thread
 
     /** Used to pass progress on to our user interface. */
     protected ProgressObserver _progobs = new ProgressObserver() {
-        public void progress (int percent) {
+        @Override
+        public void progress(int percent) {
             setStatusAsync(null, stepToGlobalPercent(percent), -1L, false);
         }
     };

--- a/src/main/java/com/threerings/getdown/launcher/Getdown.java
+++ b/src/main/java/com/threerings/getdown/launcher/Getdown.java
@@ -5,6 +5,8 @@
 
 package com.threerings.getdown.launcher;
 
+import static com.threerings.getdown.Log.log;
+
 import java.awt.BorderLayout;
 import java.awt.Container;
 import java.awt.Cursor;
@@ -14,15 +16,6 @@ import java.awt.Image;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.image.BufferedImage;
-
-import javax.imageio.ImageIO;
-import javax.swing.AbstractAction;
-import javax.swing.ImageIcon;
-import javax.swing.JApplet;
-import javax.swing.JButton;
-import javax.swing.JFrame;
-import javax.swing.JLayeredPane;
-
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -31,13 +24,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.PrintStream;
-
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLConnection;
-
 import java.security.cert.Certificate;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -50,17 +40,20 @@ import java.util.Set;
 import java.util.Timer;
 import java.util.TimerTask;
 
-import ca.beq.util.win32.registry.RegistryKey;
-import ca.beq.util.win32.registry.RegistryValue;
-import ca.beq.util.win32.registry.RootKey;
+import javax.imageio.ImageIO;
+import javax.swing.AbstractAction;
+import javax.swing.ImageIcon;
+import javax.swing.JApplet;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JLayeredPane;
 
 import com.samskivert.swing.util.SwingUtil;
 import com.samskivert.text.MessageUtil;
 import com.samskivert.util.RunAnywhere;
 import com.samskivert.util.StringUtil;
-
-import com.threerings.getdown.data.Application.UpdateInterface.Step;
 import com.threerings.getdown.data.Application;
+import com.threerings.getdown.data.Application.UpdateInterface.Step;
 import com.threerings.getdown.data.Resource;
 import com.threerings.getdown.data.SysProps;
 import com.threerings.getdown.net.Downloader;
@@ -73,7 +66,9 @@ import com.threerings.getdown.util.ProgressAggregator;
 import com.threerings.getdown.util.ProgressObserver;
 import com.threerings.getdown.util.VersionUtil;
 
-import static com.threerings.getdown.Log.log;
+import ca.beq.util.win32.registry.RegistryKey;
+import ca.beq.util.win32.registry.RegistryValue;
+import ca.beq.util.win32.registry.RootKey;
 
 /**
  * Manages the main control for the Getdown application updater and deployment system.

--- a/src/main/java/com/threerings/getdown/launcher/GetdownApp.java
+++ b/src/main/java/com/threerings/getdown/launcher/GetdownApp.java
@@ -91,6 +91,8 @@ public class GetdownApp {
 
         try {
             Getdown app = new Getdown(appDir, appId, null, null, appArgs) {
+                protected JFrame _frame;
+
                 @Override
                 protected Container createContainer() {
                     // create our user interface, and display it
@@ -194,8 +196,6 @@ public class GetdownApp {
                     }
                     super.fail(message);
                 }
-
-                protected JFrame _frame;
             };
             app.start();
 

--- a/src/main/java/com/threerings/getdown/launcher/GetdownApp.java
+++ b/src/main/java/com/threerings/getdown/launcher/GetdownApp.java
@@ -5,6 +5,8 @@
 
 package com.threerings.getdown.launcher;
 
+import static com.threerings.getdown.Log.log;
+
 import java.awt.Container;
 import java.awt.Image;
 import java.awt.event.WindowAdapter;
@@ -25,9 +27,7 @@ import com.samskivert.swing.util.SwingUtil;
 import com.samskivert.util.ArrayUtil;
 import com.samskivert.util.RunAnywhere;
 import com.samskivert.util.StringUtil;
-
 import com.threerings.getdown.data.SysProps;
-import static com.threerings.getdown.Log.log;
 
 /**
  * The main application entry point for Getdown.

--- a/src/main/java/com/threerings/getdown/launcher/GetdownApp.java
+++ b/src/main/java/com/threerings/getdown/launcher/GetdownApp.java
@@ -32,10 +32,8 @@ import com.threerings.getdown.data.SysProps;
 /**
  * The main application entry point for Getdown.
  */
-public class GetdownApp
-{
-    public static void main (String[] argv)
-    {
+public class GetdownApp {
+    public static void main(String[] argv) {
         int aidx = 0;
         List<String> args = Arrays.asList(argv);
 
@@ -56,7 +54,7 @@ public class GetdownApp
         }
 
         // pass along anything after that as app args
-        String[] appArgs = (aidx >= args.size()) ? null :
+        String[] appArgs = aidx >= args.size() ? null :
             args.subList(aidx, args.size()).toArray(ArrayUtil.EMPTY_STRING);
 
         // ensure a valid directory was supplied
@@ -94,14 +92,14 @@ public class GetdownApp
         try {
             Getdown app = new Getdown(appDir, appId, null, null, appArgs) {
                 @Override
-                protected Container createContainer () {
+                protected Container createContainer() {
                     // create our user interface, and display it
                     String title = StringUtil.isBlank(_ifc.name) ? "" : _ifc.name;
                     if (_frame == null) {
                         _frame = new JFrame(title);
                         _frame.addWindowListener(new WindowAdapter() {
                             @Override
-                            public void windowClosing (WindowEvent evt) {
+                            public void windowClosing(WindowEvent evt) {
                                 handleWindowClose();
                             }
                         });
@@ -134,7 +132,7 @@ public class GetdownApp
                 }
 
                 @Override
-                protected void showContainer () {
+                protected void showContainer() {
                     if (_frame != null) {
                         _frame.pack();
                         SwingUtil.centerWindow(_frame);
@@ -143,7 +141,7 @@ public class GetdownApp
                 }
 
                 @Override
-                protected void disposeContainer () {
+                protected void disposeContainer() {
                     if (_frame != null) {
                         _frame.dispose();
                         _frame = null;
@@ -151,7 +149,7 @@ public class GetdownApp
                 }
 
                 @Override
-                protected void showDocument (String url) {
+                protected void showDocument(String url) {
                     String[] cmdarray;
                     if (RunAnywhere.isWindows()) {
                         String osName = System.getProperty("os.name");
@@ -175,7 +173,7 @@ public class GetdownApp
                 }
 
                 @Override
-                protected void exit (int exitCode) {
+                protected void exit(int exitCode) {
                     // if we're running the app in the same JVM, don't call System.exit, but do
                     // make double sure that the download window is closed.
                     if (invokeDirect()) {
@@ -186,7 +184,7 @@ public class GetdownApp
                 }
 
                 @Override
-                protected void fail (String message) {
+                protected void fail(String message) {
                     // if the frame was set to be undecorated, make window decoration available
                     // to allow the user to close the window
                     if (_frame != null && _frame.isUndecorated()) {

--- a/src/main/java/com/threerings/getdown/launcher/GetdownApplet.java
+++ b/src/main/java/com/threerings/getdown/launcher/GetdownApplet.java
@@ -5,6 +5,8 @@
 
 package com.threerings.getdown.launcher;
 
+import static com.threerings.getdown.Log.log;
+
 import java.awt.Container;
 import java.awt.Image;
 import java.io.DataInputStream;
@@ -19,22 +21,19 @@ import java.net.MalformedURLException;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.List;
-
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
+import java.util.ArrayList;
+import java.util.List;
 
 import javax.swing.JApplet;
 import javax.swing.JPanel;
 
-import netscape.javascript.JSObject;
-
 import com.threerings.getdown.data.Application;
 import com.threerings.getdown.data.Properties;
 
-import static com.threerings.getdown.Log.log;
+import netscape.javascript.JSObject;
 
 /**
  * An applet that can be used to launch a Getdown application (when signed and given privileges).

--- a/src/main/java/com/threerings/getdown/launcher/GetdownApplet.java
+++ b/src/main/java/com/threerings/getdown/launcher/GetdownApplet.java
@@ -38,16 +38,13 @@ import netscape.javascript.JSObject;
 /**
  * An applet that can be used to launch a Getdown application (when signed and given privileges).
  */
-public class GetdownApplet extends JApplet
-    implements ImageLoader
-{
+public class GetdownApplet extends JApplet implements ImageLoader {
     /**
      * Sets the JavaScript callback to invoke when a message is received from the launched app.
      * The callback should be a function that accepts a single string parameter (the received
      * message).
      */
-    public synchronized void setMessageCallback (JSObject callback)
-    {
+    public synchronized void setMessageCallback(JSObject callback) {
         _messageCallback = callback;
     }
 
@@ -57,8 +54,7 @@ public class GetdownApplet extends JApplet
      * @return true if we succeeded in sending the message, false if the launched app has not (yet)
      * established a connection to Getdown, or the send failed.
      */
-    public synchronized boolean sendMessage (String message)
-    {
+    public synchronized boolean sendMessage(String message) {
         if (_connectOut != null) {
             try {
                 _connectOut.writeUTF(message);
@@ -70,13 +66,11 @@ public class GetdownApplet extends JApplet
         return false;
     }
 
-    @Override // documentation inherited
-    public void init ()
-    {
+    @Override
+    public void init() {
         _config = new GetdownAppletConfig(this);
 
         try {
-
             try {
                 // Check our permissions, download getdown.txt, etc.
                 _config.init();
@@ -94,39 +88,39 @@ public class GetdownApplet extends JApplet
                 log.warning("No resource certificate found, falling back to class signers");
                 for (Object signer : GetdownApplet.class.getSigners()) {
                     if (signer instanceof Certificate) {
-                        signers.add((Certificate)signer);
+                        signers.add((Certificate) signer);
                     }
                 }
             }
-            _getdown = new Getdown(_config.appdir, null, signers,
-                                   _config.jvmargs, _config.appargs) {
+            _getdown = new Getdown(_config.appdir, null, signers, _config.jvmargs,
+                    _config.appargs) {
                 @Override
-                protected Container createContainer () {
+                protected Container createContainer() {
                     getContentPane().removeAll();
                     return getContentPane();
                 }
                 @Override
-                protected RotatingBackgrounds getBackground () {
+                protected RotatingBackgrounds getBackground() {
                     return _config.getBackgroundImages(GetdownApplet.this);
                 }
                 @Override
-                protected void showContainer () {
-                    ((JPanel)getContentPane()).revalidate();
+                protected void showContainer() {
+                    ((JPanel) getContentPane()).revalidate();
                 }
                 @Override
-                protected void disposeContainer () {
+                protected void disposeContainer() {
                     // nothing to do as we're in an applet
                 }
                 @Override
-                protected boolean invokeDirect () {
+                protected boolean invokeDirect() {
                     return _config.invokeDirect;
                 }
                 @Override
-                protected JApplet getApplet () {
+                protected JApplet getApplet() {
                     return GetdownApplet.this;
                 }
                 @Override
-                protected void showDocument (String url) {
+                protected void showDocument(String url) {
                     try {
                         getAppletContext().showDocument(new URL(url), "_blank");
                     } catch (MalformedURLException e) {
@@ -134,7 +128,7 @@ public class GetdownApplet extends JApplet
                     }
                 }
                 @Override
-                protected void launch () {
+                protected void launch() {
                     // if so configured, create a server socket to listen
                     // for a connection from the app
                     if (_config.allowConnect) {
@@ -147,7 +141,7 @@ public class GetdownApplet extends JApplet
                     super.launch();
                 }
                 @Override
-                protected void exit (int exitCode) {
+                protected void exit(int exitCode) {
                     _status.stopThrob();
                     _app.releaseLock();
                     _config.redirect();
@@ -172,9 +166,7 @@ public class GetdownApplet extends JApplet
      * Attempts to start the server that will accept a connection from the launched app, allowing
      * it to exchange messages with the JavaScript context.
      */
-    protected void startConnectServer ()
-        throws IOException
-    {
+    protected void startConnectServer() throws IOException {
         // bind and set a property with the local port that will be passed through to the app
         _serverSocket = new ServerSocket(0, 0, InetAddress.getByName(null));
         String port = String.valueOf(_serverSocket.getLocalPort());
@@ -182,7 +174,7 @@ public class GetdownApplet extends JApplet
         System.setProperty(Application.PROP_PASSTHROUGH_PREFIX + Properties.CONNECT_PORT, port);
         Thread thread = new Thread("ConnectServer") {
             @Override
-            public void run () {
+            public void run() {
                 while (true) {
                     try {
                         acceptConnection();
@@ -194,7 +186,7 @@ public class GetdownApplet extends JApplet
                     }
                 }
             }
-            protected void acceptConnection () throws IOException {
+            protected void acceptConnection() throws IOException {
                 Socket socket = _serverSocket.accept();
                 log.info("App connected.", "port", socket.getPort());
                 DataInputStream connectIn = new DataInputStream(socket.getInputStream());
@@ -231,8 +223,8 @@ public class GetdownApplet extends JApplet
     }
 
     // implemented from ImageLoader
-    public Image loadImage (String path)
-    {
+    @Override
+    public Image loadImage(String path) {
         try {
             return getImage(new URL(getDocumentBase(), path));
         } catch (MalformedURLException e) {
@@ -241,9 +233,8 @@ public class GetdownApplet extends JApplet
         }
     }
 
-    @Override // documentation inherited
-    public void start ()
-    {
+    @Override
+    public void start() {
         if (_errmsg != null) {
             _getdown.fail(_errmsg);
         } else {
@@ -255,9 +246,8 @@ public class GetdownApplet extends JApplet
         }
     }
 
-    @Override // documentation inherited
-    public void stop ()
-    {
+    @Override
+    public void stop() {
         // Interrupt the getdown thread to tell it to kill its current downloading or verifying
         // before launching
         _getdown.interrupt();
@@ -265,9 +255,8 @@ public class GetdownApplet extends JApplet
         _getdown._app.releaseLock();
     }
 
-    @Override // documentation inherited
-    public synchronized void destroy ()
-    {
+    @Override
+    public synchronized void destroy() {
         if (_serverSocket != null) {
             try {
                 _serverSocket.close();
@@ -289,8 +278,7 @@ public class GetdownApplet extends JApplet
     /**
      * Creates the specified file and writes the supplied contents to it.
      */
-    protected boolean writeToFile (File tofile, String contents)
-    {
+    protected boolean writeToFile(File tofile, String contents) {
         try {
             PrintStream out = new PrintStream(new FileOutputStream(tofile));
             out.println(contents);
@@ -302,8 +290,7 @@ public class GetdownApplet extends JApplet
         }
     }
 
-    protected static Certificate loadCertificate (String path)
-    {
+    protected static Certificate loadCertificate(String path) {
         try {
             URL keyUrl = GetdownApplet.class.getClassLoader().getResource(path);
             if (keyUrl == null) {

--- a/src/main/java/com/threerings/getdown/launcher/GetdownApplet.java
+++ b/src/main/java/com/threerings/getdown/launcher/GetdownApplet.java
@@ -39,6 +39,24 @@ import netscape.javascript.JSObject;
  * An applet that can be used to launch a Getdown application (when signed and given privileges).
  */
 public class GetdownApplet extends JApplet implements ImageLoader {
+    /** The Getdown configuration as pulled from the applet params */
+    protected GetdownAppletConfig _config;
+
+    /** Handles all the actual getting down. */
+    protected Getdown _getdown;
+
+    /** An error encountered during initialization. */
+    protected String _errmsg;
+
+    /** The message callback registered by JavaScript on the containing page, if any. */
+    protected JSObject _messageCallback;
+
+    /** The server socket on which we listen for connections, if any. */
+    protected ServerSocket _serverSocket;
+
+    /** The output stream to the launched app, if a connection has been established. */
+    protected DataOutputStream _connectOut;
+
     /**
      * Sets the JavaScript callback to invoke when a message is received from the launched app.
      * The callback should be a function that accepts a single string parameter (the received
@@ -308,22 +326,4 @@ public class GetdownApplet extends JApplet implements ImageLoader {
             throw new RuntimeException(e);
         }
     }
-
-    /** The Getdown configuration as pulled from the applet params */
-    protected GetdownAppletConfig _config;
-
-    /** Handles all the actual getting down. */
-    protected Getdown _getdown;
-
-    /** An error encountered during initialization. */
-    protected String _errmsg;
-
-    /** The message callback registered by JavaScript on the containing page, if any. */
-    protected JSObject _messageCallback;
-
-    /** The server socket on which we listen for connections, if any. */
-    protected ServerSocket _serverSocket;
-
-    /** The output stream to the launched app, if a connection has been established. */
-    protected DataOutputStream _connectOut;
 }

--- a/src/main/java/com/threerings/getdown/launcher/GetdownAppletConfig.java
+++ b/src/main/java/com/threerings/getdown/launcher/GetdownAppletConfig.java
@@ -57,7 +57,6 @@ public class GetdownAppletConfig {
     public static final String APPARG_PREFIX = "appargs";
 
     public String appbase;
-
     public String appname;
 
     /** The list of background images and their display time */
@@ -78,7 +77,6 @@ public class GetdownAppletConfig {
     public URL redirectUrl;
 
     public String redirectTarget;
-
     public String installerFileContents;
 
     /** Indicates whether the downloaded app should be launched in the parent applet (true) or as a
@@ -94,6 +92,18 @@ public class GetdownAppletConfig {
     public Rectangle statusBounds;
 
     public Color statusColor;
+
+    /** A reference to the Applet in which Getdown is running */
+    protected JApplet _applet;
+
+    /** An optional prefix to prepend when looking for Getdown Applet params */
+    protected String _prefix;
+
+    /** The background images displayed on the status panel as Getdown is getting down. */
+    protected RotatingBackgrounds bgimages;
+
+    /** System properties to set in the applet JVM. */
+    protected Properties _properties = new Properties();
 
     public GetdownAppletConfig(JApplet applet) {
         this(applet, null);
@@ -385,16 +395,4 @@ public class GetdownAppletConfig {
             return false;
         }
     }
-
-    /** A reference to the Applet in which Getdown is running */
-    protected JApplet _applet;
-
-    /** An optional prefix to prepend when looking for Getdown Applet params */
-    protected String _prefix;
-
-    /** The background images displayed on the status panel as Getdown is getting down. */
-    protected RotatingBackgrounds bgimages;
-
-    /** System properties to set in the applet JVM. */
-    protected Properties _properties = new Properties();
 }

--- a/src/main/java/com/threerings/getdown/launcher/GetdownAppletConfig.java
+++ b/src/main/java/com/threerings/getdown/launcher/GetdownAppletConfig.java
@@ -5,6 +5,8 @@
 
 package com.threerings.getdown.launcher;
 
+import static com.threerings.getdown.Log.log;
+
 import java.awt.Color;
 import java.awt.Rectangle;
 import java.io.File;
@@ -23,11 +25,7 @@ import javax.swing.JApplet;
 import com.samskivert.util.RunAnywhere;
 import com.samskivert.util.StringUtil;
 import com.threerings.getdown.data.Application;
-import com.threerings.getdown.launcher.ImageLoader;
-import com.threerings.getdown.launcher.RotatingBackgrounds;
 import com.threerings.getdown.util.ConfigUtil;
-
-import static com.threerings.getdown.Log.log;
 
 public class GetdownAppletConfig
 {

--- a/src/main/java/com/threerings/getdown/launcher/GetdownAppletConfig.java
+++ b/src/main/java/com/threerings/getdown/launcher/GetdownAppletConfig.java
@@ -27,8 +27,7 @@ import com.samskivert.util.StringUtil;
 import com.threerings.getdown.data.Application;
 import com.threerings.getdown.util.ConfigUtil;
 
-public class GetdownAppletConfig
-{
+public class GetdownAppletConfig {
     public static final String APPBASE = "appbase";
     public static final String APPNAME = "appname";
     public static final String BGIMAGE = "bgimage";
@@ -96,13 +95,11 @@ public class GetdownAppletConfig
 
     public Color statusColor;
 
-    public GetdownAppletConfig (JApplet applet)
-    {
+    public GetdownAppletConfig(JApplet applet) {
         this(applet, null);
     }
 
-    public GetdownAppletConfig (JApplet applet, String paramPrefix)
-    {
+    public GetdownAppletConfig(JApplet applet, String paramPrefix) {
         _applet = applet;
         _prefix = paramPrefix;
 
@@ -191,8 +188,7 @@ public class GetdownAppletConfig
      * Does all the fiddly initialization of Getdown and throws an exception if something goes
      * horribly wrong.
      */
-    public void init () throws Exception
-    {
+    public void init() throws Exception {
         securityCheck();
         setSystemProperties();
         ensureAppdirExists();
@@ -214,8 +210,7 @@ public class GetdownAppletConfig
     /**
      * Sets getdown status panel size and text color from applet params.
      */
-    public void config (Getdown getdown)
-    {
+    public void config(Getdown getdown) {
         if (statusBounds != null) {
             getdown._ifc.status = statusBounds;
         }
@@ -227,29 +222,25 @@ public class GetdownAppletConfig
     /**
      * Gets the value of the named parameter. If the param is not set, this will return null.
      */
-    public String getParameter (String param)
-    {
-        return (_prefix == null) ?
-            _applet.getParameter(param) :
-            _applet.getParameter(_prefix + PARAM_DELIMITER + param);
+    public String getParameter(String param) {
+        return _prefix == null ? _applet.getParameter(param)
+                : _applet.getParameter(_prefix + PARAM_DELIMITER + param);
     }
 
     /**
      * Gets the value of an optional Applet parameter. If the param is not set, the default value is
      * returned.
      */
-    public String getParameter (String param, String defaultValue)
-    {
+    public String getParameter(String param, String defaultValue) {
         String value = getParameter(param);
-        return (value == null) ? defaultValue : value;
+        return value == null ? defaultValue : value;
     }
 
     /**
      * Uses the Applet context to redirect the browser to a URL (intended for use when the applet
      * is done downloading). If the redirect_on_finish parameter was not set, this does nothing.
      */
-    public void redirect ()
-    {
+    public void redirect() {
         if (redirectUrl != null) {
             if (redirectTarget == null) {
                 _applet.getAppletContext().showDocument(redirectUrl);
@@ -264,8 +255,7 @@ public class GetdownAppletConfig
      * the images have not been loaded yet. The locations of the images are pulled from the Applet
      * parameters.
      */
-    public RotatingBackgrounds getBackgroundImages (ImageLoader loader)
-    {
+    public RotatingBackgrounds getBackgroundImages(ImageLoader loader) {
         if (bgimages == null) {
             // Load background images
             bgimages = getBackgroundImages(imgpath, errorimgpath, loader);
@@ -277,9 +267,8 @@ public class GetdownAppletConfig
      * Gets the rotation background images and error image.The given image loader will be used if
      * the images have not been loaded yet.
      */
-    public static RotatingBackgrounds getBackgroundImages (String imageParam,
-        String errorImagePath, ImageLoader loader)
-    {
+    public static RotatingBackgrounds getBackgroundImages(String imageParam,
+            String errorImagePath, ImageLoader loader) {
         // Parse the image parameter and load the background images
         RotatingBackgrounds images;
         if (imageParam == null) {
@@ -295,11 +284,10 @@ public class GetdownAppletConfig
     /**
      * Parses parameters named {@code prefix0}, {@code prefix1}, ... into a list.
      */
-    protected List<String> parseArgList (String prefix)
-    {
+    protected List<String> parseArgList(String prefix) {
         List<String> arglist = new ArrayList<String>();
         String value;
-        for (int ii = 0; (value = getParameter(prefix + ii)) != null; ii++) {
+        for (int i = 0; (value = getParameter(prefix + i)) != null; i++) {
             arglist.add(value);
         }
         return arglist;
@@ -308,8 +296,7 @@ public class GetdownAppletConfig
     /**
      * This checks whether the user has accepted our signed
      */
-    protected void securityCheck () throws Exception
-    {
+    protected void securityCheck() throws Exception {
         // getdown requires full read/write permissions to the system; if we don't have this, then
         // we need to not do anything unsafe, and display a message to the user telling them they
         // need to (groan) close out of the web browser entirely and re-launch the browser, go to
@@ -327,10 +314,9 @@ public class GetdownAppletConfig
     }
 
     /**
-     * Dumps the contents of the <code>properties</code> into the System properties.
+     * Dumps the contents of the {@code properties} into the System properties.
      */
-    protected void setSystemProperties ()
-    {
+    protected void setSystemProperties() {
         System.getProperties().putAll(_properties);
     }
 
@@ -338,8 +324,7 @@ public class GetdownAppletConfig
      * Makes sire that the appdir directory exists, creating it if necessary. Throws an exception if
      * the directory does not exist and cannot be created.
      */
-    protected void ensureAppdirExists () throws Exception
-    {
+    protected void ensureAppdirExists() throws Exception {
         // if our application directory does not exist, auto-create it
         if ((!appdir.exists() || !appdir.isDirectory()) && !appdir.mkdirs()) {
             throw new Exception("m.create_appdir_failed");
@@ -349,8 +334,7 @@ public class GetdownAppletConfig
     /**
      * Writes the installer.txt and getdown.txt files to the local file system as needed.
      */
-    protected void createFiles () throws Exception
-    {
+    protected void createFiles() throws Exception {
         // if an installer.txt file is desired, create that
         if (!StringUtil.isBlank(installerFileContents)) {
             File infile = new File(appdir, "installer.txt");
@@ -364,9 +348,9 @@ public class GetdownAppletConfig
         boolean createGetdown = !gdfile.exists();
         if (!createGetdown) {
             try {
-                Map<String,Object> cdata = ConfigUtil.parseConfig(gdfile, false);
-                String oappbase = StringUtil.trim((String)cdata.get(APPBASE));
-                createGetdown = (appbase != null && !appbase.trim().equals(oappbase));
+                Map<String, Object> cdata = ConfigUtil.parseConfig(gdfile, false);
+                String oappbase = StringUtil.trim((String) cdata.get(APPBASE));
+                createGetdown = appbase != null && !appbase.trim().equals(oappbase);
                 if (createGetdown) {
                     log.warning("Recreating getdown.txt due to appbase mismatch",
                                 "nappbase", appbase, "oappbase", oappbase);
@@ -390,8 +374,7 @@ public class GetdownAppletConfig
     /**
      * Creates the specified file and writes the supplied contents to it.
      */
-    protected boolean writeToFile (File tofile, String contents)
-    {
+    protected boolean writeToFile(File tofile, String contents) {
         try {
             PrintStream out = new PrintStream(new FileOutputStream(tofile));
             out.println(contents);

--- a/src/main/java/com/threerings/getdown/launcher/ImageLoader.java
+++ b/src/main/java/com/threerings/getdown/launcher/ImageLoader.java
@@ -11,8 +11,7 @@ import java.awt.Image;
  * Abstracts away the process of loading an image so that it can be done differently in the app and
  * applet.
  */
-public interface ImageLoader
-{
+public interface ImageLoader {
     /** Loads and returns the image with the supplied path. */
-    public Image loadImage (String path);
+    public Image loadImage(String path);
 }

--- a/src/main/java/com/threerings/getdown/launcher/MultipleGetdownRunning.java
+++ b/src/main/java/com/threerings/getdown/launcher/MultipleGetdownRunning.java
@@ -10,10 +10,8 @@ import java.io.IOException;
 /**
  * Thrown when it's detected that multiple instances of the same getdown installer are running.
  */
-public class MultipleGetdownRunning extends IOException
-{
-    public MultipleGetdownRunning ()
-    {
+public class MultipleGetdownRunning extends IOException {
+    public MultipleGetdownRunning() {
         super("m.another_getdown_running");
     }
 

--- a/src/main/java/com/threerings/getdown/launcher/ProxyPanel.java
+++ b/src/main/java/com/threerings/getdown/launcher/ProxyPanel.java
@@ -26,14 +26,10 @@ import com.samskivert.swing.VGroupLayout;
 import com.samskivert.text.MessageUtil;
 
 /**
- * Displays an interface with which the user can configure their proxy
- * settings.
+ * Displays an interface with which the user can configure their proxy settings.
  */
-public class ProxyPanel extends JPanel
-    implements ActionListener
-{
-    public ProxyPanel (Getdown getdown, ResourceBundle msgs)
-    {
+public class ProxyPanel extends JPanel implements ActionListener {
+    public ProxyPanel(Getdown getdown, ResourceBundle msgs) {
         _getdown = getdown;
         _msgs = msgs;
 
@@ -76,18 +72,14 @@ public class ProxyPanel extends JPanel
         }
     }
 
-    // documentation inherited
     @Override
-    public void addNotify  ()
-    {
+    public void addNotify() {
         super.addNotify();
         _host.requestFocusInWindow();
     }
 
-    // documentation inherited
     @Override
-    public Dimension getPreferredSize ()
-    {
+    public Dimension getPreferredSize() {
         // this is annoyingly hardcoded, but we can't just force the width
         // or the JLabel will claim a bogus height thinking it can lay its
         // text out all on one line which will booch the whole UI's
@@ -95,9 +87,8 @@ public class ProxyPanel extends JPanel
         return new Dimension(500, 350);
     }
 
-    // documentation inherited from interface
-    public void actionPerformed (ActionEvent e)
-    {
+    @Override
+    public void actionPerformed(ActionEvent e) {
         String cmd = e.getActionCommand();
         if (cmd.equals("ok")) {
             // communicate this info back to getdown
@@ -110,8 +101,7 @@ public class ProxyPanel extends JPanel
     }
 
     /** Used to look up localized messages. */
-    protected String get (String key)
-    {
+    protected String get(String key) {
         // if this string is tainted, we don't translate it, instead we
         // simply remove the taint character and return it to the caller
         if (MessageUtil.isTainted(key)) {
@@ -125,10 +115,9 @@ public class ProxyPanel extends JPanel
         }
     }
 
-    protected static class SaneTextField extends JTextField
-    {
+    protected static class SaneTextField extends JTextField {
         @Override
-        public Dimension getPreferredSize () {
+        public Dimension getPreferredSize() {
             Dimension d = super.getPreferredSize();
             d.width = Math.max(d.width, 150);
             return d;

--- a/src/main/java/com/threerings/getdown/launcher/ProxyPanel.java
+++ b/src/main/java/com/threerings/getdown/launcher/ProxyPanel.java
@@ -5,11 +5,12 @@
 
 package com.threerings.getdown.launcher;
 
+import static com.threerings.getdown.Log.log;
+
 import java.awt.BorderLayout;
 import java.awt.Dimension;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
 
@@ -23,8 +24,6 @@ import com.samskivert.swing.GroupLayout;
 import com.samskivert.swing.Spacer;
 import com.samskivert.swing.VGroupLayout;
 import com.samskivert.text.MessageUtil;
-
-import static com.threerings.getdown.Log.log;
 
 /**
  * Displays an interface with which the user can configure their proxy

--- a/src/main/java/com/threerings/getdown/launcher/ProxyPanel.java
+++ b/src/main/java/com/threerings/getdown/launcher/ProxyPanel.java
@@ -29,6 +29,21 @@ import com.samskivert.text.MessageUtil;
  * Displays an interface with which the user can configure their proxy settings.
  */
 public class ProxyPanel extends JPanel implements ActionListener {
+    protected static class SaneTextField extends JTextField {
+        @Override
+        public Dimension getPreferredSize() {
+            Dimension d = super.getPreferredSize();
+            d.width = Math.max(d.width, 150);
+            return d;
+        }
+    }
+
+    protected Getdown _getdown;
+    protected ResourceBundle _msgs;
+
+    protected JTextField _host;
+    protected JTextField _port;
+
     public ProxyPanel(Getdown getdown, ResourceBundle msgs) {
         _getdown = getdown;
         _msgs = msgs;
@@ -114,19 +129,4 @@ public class ProxyPanel extends JPanel implements ActionListener {
             return key;
         }
     }
-
-    protected static class SaneTextField extends JTextField {
-        @Override
-        public Dimension getPreferredSize() {
-            Dimension d = super.getPreferredSize();
-            d.width = Math.max(d.width, 150);
-            return d;
-        }
-    }
-
-    protected Getdown _getdown;
-    protected ResourceBundle _msgs;
-
-    protected JTextField _host;
-    protected JTextField _port;
 }

--- a/src/main/java/com/threerings/getdown/launcher/RotatingBackgrounds.java
+++ b/src/main/java/com/threerings/getdown/launcher/RotatingBackgrounds.java
@@ -9,20 +9,16 @@ import static com.threerings.getdown.Log.log;
 
 import java.awt.Image;
 
-public class RotatingBackgrounds
-{
-
+public class RotatingBackgrounds {
     /**
      * Creates a placeholder if there are no images. Just returns null from getImage every time.
      */
-    public RotatingBackgrounds ()
-    {
+    public RotatingBackgrounds() {
         makeEmpty();
     }
 
     /** Creates a single image background. */
-    public RotatingBackgrounds (Image background)
-    {
+    public RotatingBackgrounds(Image background) {
         percentages = new int[] { 0 };
         minDisplayTime = new int[] { 0 };
         images = new Image[] { background };
@@ -30,7 +26,7 @@ public class RotatingBackgrounds
     }
 
     /**
-     * Create a sequence of images to be rotated through from <code>backgrounds</code>.
+     * Create a sequence of images to be rotated through from {@code backgrounds}.
      *
      * Each String in backgrounds should be the path to the image, a semicolon, and the minimum
      * amount of time to display the image in seconds. Each image will be active for an equal
@@ -38,28 +34,27 @@ public class RotatingBackgrounds
      * time when the next should be shown. In that case, it's left up until its been there for its
      * minimum display time and then the next one gets to come up.
      */
-    public RotatingBackgrounds (String[] backgrounds, String errorBackground, ImageLoader loader)
-    {
+    public RotatingBackgrounds(String[] backgrounds, String errorBackground, ImageLoader loader) {
         percentages = new int[backgrounds.length];
         minDisplayTime = new int[backgrounds.length];
         images = new Image[backgrounds.length];
-        for (int ii = 0; ii < backgrounds.length; ii++) {
-            String[] pieces = backgrounds[ii].split(";");
+        for (int i = 0; i < backgrounds.length; i++) {
+            String[] pieces = backgrounds[i].split(";");
             if (pieces.length != 2) {
-                log.warning("Unable to parse background image '" + backgrounds[ii] + "'");
+                log.warning("Unable to parse background image '" + backgrounds[i] + "'");
                 makeEmpty();
                 return;
             }
-            images[ii] = loader.loadImage(pieces[0]);
+            images[i] = loader.loadImage(pieces[0]);
             try {
-                minDisplayTime[ii] = Integer.parseInt(pieces[1]);
+                minDisplayTime[i] = Integer.parseInt(pieces[1]);
             } catch (NumberFormatException e) {
-                log.warning("Unable to parse background image display time '" +
-                            backgrounds[ii] + "'");
+                log.warning("Unable to parse background image display time '"
+                        + backgrounds[i] + "'");
                 makeEmpty();
                 return;
             }
-            percentages[ii] = (int)((ii/(float)backgrounds.length) * 100);
+            percentages[i] = (int) (i / (float) backgrounds.length * 100);
         }
         if (errorBackground == null) {
             errorImage = images[0];
@@ -71,15 +66,14 @@ public class RotatingBackgrounds
     /**
      * @return the image to display at the given progress or null if there aren't any.
      */
-    public Image getImage (int progress)
-    {
+    public Image getImage(int progress) {
         if (images.length == 0) {
             return null;
         }
         long now = System.currentTimeMillis();
         if (current != images.length - 1
-            && (current == -1 || (progress >= percentages[current + 1] &&
-                    (now - currentDisplayStart) / 1000 > minDisplayTime[current]))) {
+                && (current == -1 || progress >= percentages[current + 1]
+                        && (now - currentDisplayStart) / 1000 > minDisplayTime[current])) {
             current++;
             currentDisplayStart = now;
         }
@@ -89,8 +83,7 @@ public class RotatingBackgrounds
     /**
      * Returns the image to display if an error has caused getdown to fail.
      */
-    public Image getErrorImage ()
-    {
+    public Image getErrorImage() {
         return errorImage;
     }
 
@@ -101,8 +94,7 @@ public class RotatingBackgrounds
         return images.length;
     }
 
-    protected void makeEmpty ()
-    {
+    protected void makeEmpty() {
         percentages = new int[] {};
         minDisplayTime = new int[] {};
         images = new Image[] {};

--- a/src/main/java/com/threerings/getdown/launcher/RotatingBackgrounds.java
+++ b/src/main/java/com/threerings/getdown/launcher/RotatingBackgrounds.java
@@ -10,6 +10,23 @@ import static com.threerings.getdown.Log.log;
 import java.awt.Image;
 
 public class RotatingBackgrounds {
+    /** Time at which the currently displayed image was first displayed in millis. */
+    protected long currentDisplayStart;
+
+    /** The index of the currently displayed image or -1 if we haven't displayed any. */
+    protected int current = -1;
+
+    protected Image[] images;
+
+    /** The image to display if getdown has failed due to an error. */
+    protected Image errorImage;
+
+    /** Percentage at which each image should be displayed. */
+    protected int[] percentages;
+
+    /** Time to show each image in seconds. */
+    protected int[] minDisplayTime;
+
     /**
      * Creates a placeholder if there are no images. Just returns null from getImage every time.
      */
@@ -99,21 +116,4 @@ public class RotatingBackgrounds {
         minDisplayTime = new int[] {};
         images = new Image[] {};
     }
-
-    /** Time at which the currently displayed image was first displayed in millis. */
-    protected long currentDisplayStart;
-
-    /** The index of the currently displayed image or -1 if we haven't displayed any. */
-    protected int current = -1;
-
-    protected Image[] images;
-
-    /** The image to display if getdown has failed due to an error. */
-    protected Image errorImage;
-
-    /** Percentage at which each image should be displayed. */
-    protected int[] percentages;
-
-    /** Time to show each image in seconds. */
-    protected int[] minDisplayTime;
 }

--- a/src/main/java/com/threerings/getdown/launcher/RotatingBackgrounds.java
+++ b/src/main/java/com/threerings/getdown/launcher/RotatingBackgrounds.java
@@ -5,9 +5,9 @@
 
 package com.threerings.getdown.launcher;
 
-import java.awt.Image;
-
 import static com.threerings.getdown.Log.log;
+
+import java.awt.Image;
 
 public class RotatingBackgrounds
 {
@@ -31,7 +31,7 @@ public class RotatingBackgrounds
 
     /**
      * Create a sequence of images to be rotated through from <code>backgrounds</code>.
-     * 
+     *
      * Each String in backgrounds should be the path to the image, a semicolon, and the minimum
      * amount of time to display the image in seconds. Each image will be active for an equal
      * percentage of the download process, unless one hasn't been active for its minimum display
@@ -78,7 +78,7 @@ public class RotatingBackgrounds
         }
         long now = System.currentTimeMillis();
         if (current != images.length - 1
-            && (current == -1 || (progress >= percentages[current + 1] && 
+            && (current == -1 || (progress >= percentages[current + 1] &&
                     (now - currentDisplayStart) / 1000 > minDisplayTime[current]))) {
             current++;
             currentDisplayStart = now;
@@ -110,18 +110,18 @@ public class RotatingBackgrounds
 
     /** Time at which the currently displayed image was first displayed in millis. */
     protected long currentDisplayStart;
-    
+
     /** The index of the currently displayed image or -1 if we haven't displayed any. */
     protected int current = -1;
-    
+
     protected Image[] images;
-    
+
     /** The image to display if getdown has failed due to an error. */
     protected Image errorImage;
-    
+
     /** Percentage at which each image should be displayed. */
     protected int[] percentages;
-    
+
     /** Time to show each image in seconds. */
     protected int[] minDisplayTime;
 }

--- a/src/main/java/com/threerings/getdown/launcher/StatusPanel.java
+++ b/src/main/java/com/threerings/getdown/launcher/StatusPanel.java
@@ -35,28 +35,25 @@ import com.threerings.getdown.data.Application.UpdateInterface;
 /**
  * Displays download and patching status.
  */
-public class StatusPanel extends JComponent
-    implements ImageObserver
-{
-    public StatusPanel (ResourceBundle msgs)
-    {
+public class StatusPanel extends JComponent implements ImageObserver {
+    public StatusPanel(ResourceBundle msgs) {
         _msgs = msgs;
 
         // Add a bit of "throbbing" to the display by updating the number of dots displayed after
         // our status. This lets users know things are still working.
-        _timer = new Timer(1000,
-            new ActionListener() {
-                public void actionPerformed (ActionEvent event) {
-                    if (_status != null && !_displayError) {
-                        _statusDots = (_statusDots % 3) + 1; // 1, 2, 3, 1, 2, 3, etc.
-                        updateStatusLabel();
-                    }
+        _timer = new Timer(1000, new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent event) {
+                if (_status != null && !_displayError) {
+                    // 1, 2, 3, 1, 2, 3, etc.
+                    _statusDots = _statusDots % 3 + 1;
+                    updateStatusLabel();
                 }
-            });
+            }
+        });
     }
 
-    public void init (UpdateInterface ifc, RotatingBackgrounds bg, Image barimg)
-    {
+    public void init(UpdateInterface ifc, RotatingBackgrounds bg, Image barimg) {
         _ifc = ifc;
         _bg = bg;
         Image img = _bg.getImage(_progress);
@@ -75,8 +72,7 @@ public class StatusPanel extends JComponent
     }
 
     @Override
-    public boolean imageUpdate (Image img, int infoflags, int x, int y, int width, int height)
-    {
+    public boolean imageUpdate(Image img, int infoflags, int x, int y, int width, int height) {
         boolean updated = false;
         if ((infoflags | WIDTH) != 0) {
             _psize.width = width;
@@ -97,8 +93,7 @@ public class StatusPanel extends JComponent
     /**
      * Adjusts the progress display to the specified percentage.
      */
-    public void setProgress (int percent, long remaining)
-    {
+    public void setProgress(int percent, long remaining) {
         boolean needsRepaint = false;
 
         // maybe update the progress label
@@ -115,7 +110,7 @@ public class StatusPanel extends JComponent
         if (remaining > 1) {
             // skip this estimate if it's been less than a second since our last one came in
             if (!_rthrottle.throttleOp()) {
-                _remain[_ridx++%_remain.length] = remaining;
+                _remain[_ridx++ % _remain.length] = remaining;
             }
 
             // smooth the remaining time by taking the trailing average of the last four values
@@ -128,8 +123,8 @@ public class StatusPanel extends JComponent
 
             if (!_ifc.hideProgressText) {
                 // now compute our display value
-                int minutes = (int)(remaining / 60), seconds = (int)(remaining % 60);
-                String remstr = minutes + ":" + ((seconds < 10) ? "0" : "") + seconds;
+                int minutes = (int) (remaining / 60), seconds = (int) (remaining % 60);
+                String remstr = minutes + ":" + (seconds < 10 ? "0" : "") + seconds;
                 String msg = MessageFormat.format(get("m.remain"), remstr);
                 _newrlab = createLabel(msg, _ifc.statusText);
             }
@@ -150,8 +145,7 @@ public class StatusPanel extends JComponent
     /**
      * Displays the specified status string.
      */
-    public void setStatus (String status, boolean displayError)
-    {
+    public void setStatus(String status, boolean displayError) {
         _status = xlate(status);
         _displayError = displayError;
         updateStatusLabel();
@@ -160,33 +154,28 @@ public class StatusPanel extends JComponent
     /**
      * Stop the throbbing.
      */
-    public void stopThrob ()
-    {
+    public void stopThrob() {
         _timer.stop();
         _statusDots = 3;
         updateStatusLabel();
     }
 
     @Override
-    public void addNotify ()
-    {
+    public void addNotify() {
         super.addNotify();
         _timer.start();
     }
 
     @Override
-    public void removeNotify ()
-    {
+    public void removeNotify() {
         _timer.stop();
         super.removeNotify();
     }
 
-    // documentation inherited
     @Override
-    public void paintComponent (Graphics g)
-    {
+    public void paintComponent(Graphics g) {
         super.paintComponent(g);
-        Graphics2D gfx = (Graphics2D)g;
+        Graphics2D gfx = (Graphics2D) g;
 
         // always draw a background in case our image isn't ready yet
         gfx.setColor(_ifc.background);
@@ -254,18 +243,15 @@ public class StatusPanel extends JComponent
         SwingUtil.restoreAntiAliasing(gfx, oalias);
     }
 
-    // documentation inherited
     @Override
-    public Dimension getPreferredSize ()
-    {
+    public Dimension getPreferredSize() {
         return _psize;
     }
 
     /**
      * Update the status label.
      */
-    protected void updateStatusLabel ()
-    {
+    protected void updateStatusLabel() {
         String status = _status;
         if (!_displayError) {
             for (int ii = 0; ii < _statusDots; ii++) {
@@ -289,22 +275,20 @@ public class StatusPanel extends JComponent
     /**
      * Get the y coordinate of a label in the status area.
      */
-    protected int getStatusY (Label label)
-    {
+    protected int getStatusY(Label label) {
         // if the status region is higher than the progress region, we
         // want to align the label with the bottom of its region
         // rather than the top
         if (_ifc.status.y > _ifc.progress.y) {
             return _ifc.status.y;
         }
-        return _ifc.status.y + (_ifc.status.height - label.getSize().height);
+        return _ifc.status.y + _ifc.status.height - label.getSize().height;
     }
 
     /**
      * Create a label, taking care of adding the shadow if needed.
      */
-    protected Label createLabel (String text, Color color)
-    {
+    protected Label createLabel(String text, Color color) {
         Label label = new Label(text, color, FONT);
         if (_ifc.textShadow != null) {
             label.setAlternateColor(_ifc.textShadow);
@@ -314,8 +298,7 @@ public class StatusPanel extends JComponent
     }
 
     /** Used by {@link #setStatus}. */
-    protected String xlate (String compoundKey)
-    {
+    protected String xlate(String compoundKey) {
         // to be more efficient about creating unnecessary objects, we
         // do some checking before splitting
         int tidx = compoundKey.indexOf('|');
@@ -324,7 +307,7 @@ public class StatusPanel extends JComponent
 
         } else {
             String key = compoundKey.substring(0, tidx);
-            String argstr = compoundKey.substring(tidx+1);
+            String argstr = compoundKey.substring(tidx + 1);
             String[] args = StringUtil.split(argstr, "|");
             // unescape and translate the arguments
             for (int i = 0; i < args.length; i++) {
@@ -341,17 +324,14 @@ public class StatusPanel extends JComponent
     }
 
     /** Used by {@link #setStatus}. */
-    protected String get (String key, Object[] args)
-    {
+    protected String get(String key, Object[] args) {
         String msg = get(key);
-        return (msg != null) ?
-            MessageFormat.format(MessageUtil.escape(msg), args)
-            : (key + StringUtil.toString(args));
+        return msg != null ? MessageFormat.format(MessageUtil.escape(msg), args)
+                : key + StringUtil.toString(args);
     }
 
     /** Used by {@link #setStatus}, and {@link #setProgress}. */
-    protected String get (String key)
-    {
+    protected String get(String key) {
         // if we have no _msgs that means we're probably recovering from a
         // failure to load the translation messages in the first place, so
         // just give them their key back because it's probably an english

--- a/src/main/java/com/threerings/getdown/launcher/StatusPanel.java
+++ b/src/main/java/com/threerings/getdown/launcher/StatusPanel.java
@@ -5,6 +5,8 @@
 
 package com.threerings.getdown.launcher;
 
+import static com.threerings.getdown.Log.log;
+
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Font;
@@ -28,10 +30,7 @@ import com.samskivert.swing.util.SwingUtil;
 import com.samskivert.text.MessageUtil;
 import com.samskivert.util.StringUtil;
 import com.samskivert.util.Throttle;
-
 import com.threerings.getdown.data.Application.UpdateInterface;
-
-import static com.threerings.getdown.Log.log;
 
 /**
  * Displays download and patching status.

--- a/src/main/java/com/threerings/getdown/launcher/StatusPanel.java
+++ b/src/main/java/com/threerings/getdown/launcher/StatusPanel.java
@@ -36,6 +36,29 @@ import com.threerings.getdown.data.Application.UpdateInterface;
  * Displays download and patching status.
  */
 public class StatusPanel extends JComponent implements ImageObserver {
+    protected static final Font FONT = new Font("SansSerif", Font.BOLD, 12);
+
+    protected Image _barimg;
+    protected RotatingBackgrounds _bg;
+    protected Dimension _psize;
+
+    protected ResourceBundle _msgs;
+
+    protected int _progress = -1;
+    protected String _status;
+    protected int _statusDots = 1;
+    protected boolean _displayError;
+    protected Label _label, _newlab;
+    protected Label _plabel, _newplab;
+    protected Label _rlabel, _newrlab;
+
+    protected UpdateInterface _ifc;
+    protected Timer _timer;
+
+    protected long[] _remain = new long[4];
+    protected int _ridx;
+    protected Throttle _rthrottle = new Throttle(1, 1000L);
+
     public StatusPanel(ResourceBundle msgs) {
         _msgs = msgs;
 
@@ -352,27 +375,4 @@ public class StatusPanel extends JComponent implements ImageObserver {
             return key;
         }
     }
-
-    protected Image _barimg;
-    protected RotatingBackgrounds _bg;
-    protected Dimension _psize;
-
-    protected ResourceBundle _msgs;
-
-    protected int _progress = -1;
-    protected String _status;
-    protected int _statusDots = 1;
-    protected boolean _displayError;
-    protected Label _label, _newlab;
-    protected Label _plabel, _newplab;
-    protected Label _rlabel, _newrlab;
-
-    protected UpdateInterface _ifc;
-    protected Timer _timer;
-
-    protected long[] _remain = new long[4];
-    protected int _ridx;
-    protected Throttle _rthrottle = new Throttle(1, 1000L);
-
-    protected static final Font FONT = new Font("SansSerif", Font.BOLD, 12);
 }

--- a/src/main/java/com/threerings/getdown/net/DownloadAbortedException.java
+++ b/src/main/java/com/threerings/getdown/net/DownloadAbortedException.java
@@ -10,6 +10,5 @@ import java.io.IOException;
 /**
  * Used to terminate the download process in its midst.
  */
-public class DownloadAbortedException extends IOException
-{
+public class DownloadAbortedException extends IOException {
 }

--- a/src/main/java/com/threerings/getdown/net/Downloader.java
+++ b/src/main/java/com/threerings/getdown/net/Downloader.java
@@ -22,6 +22,38 @@ import com.threerings.getdown.data.Resource;
  */
 public abstract class Downloader extends Thread {
     /**
+     * The delay in milliseconds between notifying progress observers of file download progress.
+     */
+    protected static final long UPDATE_DELAY = 500L;
+
+    /** The list of resources to be downloaded. */
+    protected List<Resource> _resources;
+
+    /** The reported sizes of our resources. */
+    protected Map<Resource, Long> _sizes = new HashMap<Resource, Long>();
+
+    /** The bytes downloaded for each resource. */
+    protected Map<Resource, Long> _downloaded = new HashMap<Resource, Long>();
+
+    /** The observer with whom we are communicating. */
+    protected Observer _obs;
+
+    /** Used while downloading. */
+    protected byte[] _buffer = new byte[4096];
+
+    /** The time at which the file transfer began. */
+    protected long _start;
+
+    /** The current transfer rate in bytes per second. */
+    protected long _bytesPerSecond;
+
+    /** The time at which the last progress update was posted to the progress observer. */
+    protected long _lastUpdate;
+
+    /** Whether the download has completed and the progress observer notified. */
+    protected boolean _complete;
+
+    /**
      * An interface used to communicate status back to an external entity.  <em>Note:</em> these
      * methods are all called on the download thread, so implementors must take care to only
      * execute thread-safe code or simply pass a message to the AWT thread, for example.
@@ -217,35 +249,4 @@ public abstract class Downloader extends Thread {
      * protocol-specific code
      */
     protected abstract void doDownload(Resource rsrc) throws IOException;
-
-    /** The list of resources to be downloaded. */
-    protected List<Resource> _resources;
-
-    /** The reported sizes of our resources. */
-    protected Map<Resource, Long> _sizes = new HashMap<Resource, Long>();
-
-    /** The bytes downloaded for each resource. */
-    protected Map<Resource, Long> _downloaded = new HashMap<Resource, Long>();
-
-    /** The observer with whom we are communicating. */
-    protected Observer _obs;
-
-    /** Used while downloading. */
-    protected byte[] _buffer = new byte[4096];
-
-    /** The time at which the file transfer began. */
-    protected long _start;
-
-    /** The current transfer rate in bytes per second. */
-    protected long _bytesPerSecond;
-
-    /** The time at which the last progress update was posted to the progress observer. */
-    protected long _lastUpdate;
-
-    /** Whether the download has completed and the progress observer notified. */
-    protected boolean _complete;
-
-    /** The delay in milliseconds between notifying progress observers of file download
-     * progress. */
-    protected static final long UPDATE_DELAY = 500L;
 }

--- a/src/main/java/com/threerings/getdown/net/Downloader.java
+++ b/src/main/java/com/threerings/getdown/net/Downloader.java
@@ -5,16 +5,15 @@
 
 package com.threerings.getdown.net;
 
+import static com.threerings.getdown.Log.log;
+
 import java.io.File;
 import java.io.IOException;
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import com.threerings.getdown.data.Resource;
-
-import static com.threerings.getdown.Log.log;
 
 /**
  * Handles the download of a collection of files, first issuing HTTP head requests to obtain size
@@ -209,7 +208,7 @@ public abstract class Downloader extends Thread
                     throw new DownloadAbortedException();
                 }
             }
-        }   
+        }
     }
 
     /**

--- a/src/main/java/com/threerings/getdown/net/HTTPDownloader.java
+++ b/src/main/java/com/threerings/getdown/net/HTTPDownloader.java
@@ -21,28 +21,24 @@ import com.threerings.getdown.util.ConnectionUtil;
 /**
  * Implements downloading files over HTTP
  */
-public class HTTPDownloader extends Downloader
-{
-    public HTTPDownloader (List<Resource> resources, Observer obs)
-    {
+public class HTTPDownloader extends Downloader {
+    public HTTPDownloader(List<Resource> resources, Observer obs) {
         super(resources, obs);
     }
 
     @Override
-    protected long checkSize (Resource rsrc)
-        throws IOException
-    {
+    protected long checkSize(Resource rsrc) throws IOException {
         URLConnection conn = ConnectionUtil.open(rsrc.getRemote());
         try {
             // if we're accessing our data via HTTP, we only need a HEAD request
             if (conn instanceof HttpURLConnection) {
-                HttpURLConnection hcon = (HttpURLConnection)conn;
+                HttpURLConnection hcon = (HttpURLConnection) conn;
                 hcon.setRequestMethod("HEAD");
                 hcon.connect();
                 // make sure we got a satisfactory response code
                 if (hcon.getResponseCode() != HttpURLConnection.HTTP_OK) {
-                    throw new IOException("Unable to check up-to-date for " +
-                                          rsrc.getRemote() + ": " + hcon.getResponseCode());
+                    throw new IOException("Unable to check up-to-date for "
+                            + rsrc.getRemote() + ": " + hcon.getResponseCode());
                 }
             }
             return conn.getContentLength();
@@ -54,19 +50,17 @@ public class HTTPDownloader extends Downloader
     }
 
     @Override
-    protected void doDownload (Resource rsrc)
-        throws IOException
-    {
+    protected void doDownload(Resource rsrc) throws IOException {
         // download the resource from the specified URL
         URLConnection conn = ConnectionUtil.open(rsrc.getRemote());
         conn.connect();
 
         // make sure we got a satisfactory response code
         if (conn instanceof HttpURLConnection) {
-            HttpURLConnection hcon = (HttpURLConnection)conn;
+            HttpURLConnection hcon = (HttpURLConnection) conn;
             if (hcon.getResponseCode() != HttpURLConnection.HTTP_OK) {
-                throw new IOException("Unable to download resource " + rsrc.getRemote() + ": " +
-                                      hcon.getResponseCode());
+                throw new IOException("Unable to download resource " + rsrc.getRemote() + ": "
+                        + hcon.getResponseCode());
             }
         }
 

--- a/src/main/java/com/threerings/getdown/net/HTTPDownloader.java
+++ b/src/main/java/com/threerings/getdown/net/HTTPDownloader.java
@@ -5,6 +5,8 @@
 
 package com.threerings.getdown.net;
 
+import static com.threerings.getdown.Log.log;
+
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -13,11 +15,8 @@ import java.net.URLConnection;
 import java.util.List;
 
 import com.samskivert.io.StreamUtil;
-
 import com.threerings.getdown.data.Resource;
 import com.threerings.getdown.util.ConnectionUtil;
-
-import static com.threerings.getdown.Log.log;
 
 /**
  * Implements downloading files over HTTP

--- a/src/main/java/com/threerings/getdown/tools/AppletParamSigner.java
+++ b/src/main/java/com/threerings/getdown/tools/AppletParamSigner.java
@@ -17,10 +17,8 @@ import org.apache.commons.codec.binary.Base64;
  * Produces a signed hash of the appbase, appname, and image path to ensure that signed copies of
  * Getdown are not hijacked to run malicious code.
  */
-public class AppletParamSigner
-{
-    public static void main (String[] args)
-    {
+public class AppletParamSigner {
+    public static void main(String[] args) {
         try {
             if (args.length != 7) {
                 System.err.println("AppletParamSigner keystore storepass alias keypass " +
@@ -40,7 +38,7 @@ public class AppletParamSigner
             KeyStore store = KeyStore.getInstance("JKS");
             store.load(new BufferedInputStream(new FileInputStream(keystore)),
                        storepass.toCharArray());
-            PrivateKey key = (PrivateKey)store.getKey(alias, keypass.toCharArray());
+            PrivateKey key = (PrivateKey) store.getKey(alias, keypass.toCharArray());
             Signature sig = Signature.getInstance("SHA1withRSA");
             sig.initSign(key);
             sig.update(params.getBytes());

--- a/src/main/java/com/threerings/getdown/tools/Differ.java
+++ b/src/main/java/com/threerings/getdown/tools/Differ.java
@@ -30,29 +30,26 @@ import com.threerings.getdown.data.Resource;
  * revisions are bundled into a single patch file which is placed into the
  * target version directory.
  */
-public class Differ
-{
+public class Differ {
     /**
      * Creates a single patch file that contains the differences between
      * the two specified application directories. The patch file will be
-     * created in the <code>nvdir</code> directory with name
+     * created in the {@code nvdir} directory with name
      * <code>patchV.dat</code> where V is the old application version.
      */
-    public void createDiff (File nvdir, File ovdir, boolean verbose)
-        throws IOException
-    {
+    public void createDiff(File nvdir, File ovdir, boolean verbose) throws IOException {
         // sanity check
         String nvers = nvdir.getName();
         String overs = ovdir.getName();
         try {
             if (Long.parseLong(nvers) <= Long.parseLong(overs)) {
-                String err = "New version (" + nvers + ") must be greater " +
-                    "than old version (" + overs + ").";
+                String err = "New version (" + nvers + ") must be greater "
+                    + "than old version (" + overs + ").";
                 throw new IOException(err);
             }
         } catch (NumberFormatException nfe) {
-            throw new IOException("Non-numeric versions? [nvers=" + nvers +
-                                  ", overs=" + overs + "].");
+            throw new IOException("Non-numeric versions? [nvers=" + nvers
+                    + ", overs=" + overs + "].");
         }
 
         Application oapp = new Application(ovdir, null);
@@ -87,10 +84,8 @@ public class Differ
         }
     }
 
-    protected void createPatch (File patch, ArrayList<Resource> orsrcs,
-                                ArrayList<Resource> nrsrcs, boolean verbose)
-        throws IOException
-    {
+    protected void createPatch(File patch, ArrayList<Resource> orsrcs, ArrayList<Resource> nrsrcs,
+            boolean verbose) throws IOException {
         MessageDigest md = Digest.getMessageDigest();
         JarOutputStream jout = null;
         try {
@@ -101,7 +96,7 @@ public class Differ
             // in the old application, or it is new
             for (Resource rsrc : nrsrcs) {
                 int oidx = orsrcs.indexOf(rsrc);
-                Resource orsrc = (oidx == -1) ? null : orsrcs.remove(oidx);
+                Resource orsrc = oidx == -1 ? null : orsrcs.remove(oidx);
                 if (orsrc != null) {
                     // first see if they are the same
                     String odig = orsrc.computeDigest(md, null);
@@ -166,15 +161,13 @@ public class Differ
         }
     }
 
-    protected File rebuildJar (File target)
-        throws IOException
-    {
+    protected File rebuildJar(File target) throws IOException {
         JarFile jar = new JarFile(target);
         File temp = File.createTempFile("differ", "jar");
         JarOutputStream jout = new JarOutputStream(
             new BufferedOutputStream(new FileOutputStream(temp)));
         byte[] buffer = new byte[4096];
-        for (Enumeration<JarEntry> iter = jar.entries(); iter.hasMoreElements(); ) {
+        for (Enumeration<JarEntry> iter = jar.entries(); iter.hasMoreElements();) {
             JarEntry entry = iter.nextElement();
             entry.setCompressedSize(-1);
             jout.putNextEntry(entry);
@@ -191,14 +184,11 @@ public class Differ
         return temp;
     }
 
-    protected void jarDiff (File ofile, File nfile, JarOutputStream jout)
-        throws IOException
-    {
+    protected void jarDiff(File ofile, File nfile, JarOutputStream jout) throws IOException {
         JarDiff.createPatch(ofile.getPath(), nfile.getPath(), jout, false);
     }
 
-    public static void main (String[] args)
-    {
+    public static void main(String[] args) {
         if (args.length < 2) {
             System.err.println(
                 "Usage: Differ [-verbose] new_vers_dir old_vers_dir");
@@ -220,9 +210,7 @@ public class Differ
         }
     }
 
-    protected static void pipe (File file, JarOutputStream jout)
-        throws IOException
-    {
+    protected static void pipe(File file, JarOutputStream jout) throws IOException {
         FileInputStream fin = null;
         try {
             StreamUtil.copy(fin = new FileInputStream(file), jout);

--- a/src/main/java/com/threerings/getdown/tools/Differ.java
+++ b/src/main/java/com/threerings/getdown/tools/Differ.java
@@ -11,7 +11,7 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-
+import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.jar.JarEntry;
@@ -19,10 +19,7 @@ import java.util.jar.JarFile;
 import java.util.jar.JarOutputStream;
 import java.util.zip.ZipEntry;
 
-import java.security.MessageDigest;
-
 import com.samskivert.io.StreamUtil;
-
 import com.threerings.getdown.data.Application;
 import com.threerings.getdown.data.Digest;
 import com.threerings.getdown.data.Resource;

--- a/src/main/java/com/threerings/getdown/tools/Digester.java
+++ b/src/main/java/com/threerings/getdown/tools/Digester.java
@@ -9,12 +9,10 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
-
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
 import java.security.PrivateKey;
 import java.security.Signature;
-
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/com/threerings/getdown/tools/Digester.java
+++ b/src/main/java/com/threerings/getdown/tools/Digester.java
@@ -26,14 +26,11 @@ import com.threerings.getdown.data.Resource;
 /**
  * Handles the generation of the digest.txt file.
  */
-public class Digester
-{
+public class Digester {
     /**
      * A command line entry point for the digester.
      */
-    public static void main (String[] args)
-        throws IOException, GeneralSecurityException
-    {
+    public static void main(String[] args) throws IOException, GeneralSecurityException {
         if (args.length != 1 && args.length != 4) {
             System.err.println("Usage: Digester app_dir [keystore_path password alias]");
             System.exit(255);
@@ -48,9 +45,7 @@ public class Digester
     /**
      * Creates a digest file in the specified application directory.
      */
-    public static void createDigest (File appdir)
-        throws IOException
-    {
+    public static void createDigest(File appdir) throws IOException {
         File target = new File(appdir, Digest.DIGEST_FILE);
         System.out.println("Generating digest file '" + target + "'...");
 
@@ -74,9 +69,8 @@ public class Digester
     /**
      * Creates a digest file in the specified application directory.
      */
-    public static void signDigest (File appdir, File storePath, String storePass, String storeAlias)
-        throws IOException, GeneralSecurityException
-    {
+    public static void signDigest(File appdir, File storePath, String storePass, String storeAlias)
+            throws IOException, GeneralSecurityException {
         File inputFile = new File(appdir, Digest.DIGEST_FILE);
         File signatureFile = new File(appdir, Digest.DIGEST_FILE + Application.SIGNATURE_SUFFIX);
 
@@ -87,7 +81,7 @@ public class Digester
             KeyStore store = KeyStore.getInstance("JKS");
             storeInput = new FileInputStream(storePath);
             store.load(storeInput, storePass.toCharArray());
-            PrivateKey key = (PrivateKey)store.getKey(storeAlias, storePass.toCharArray());
+            PrivateKey key = (PrivateKey) store.getKey(storeAlias, storePass.toCharArray());
 
             // sign the digest file
             Signature sig = Signature.getInstance("SHA1withRSA");

--- a/src/main/java/com/threerings/getdown/tools/DigesterTask.java
+++ b/src/main/java/com/threerings/getdown/tools/DigesterTask.java
@@ -7,7 +7,6 @@ package com.threerings.getdown.tools;
 
 import java.io.File;
 import java.io.IOException;
-
 import java.security.GeneralSecurityException;
 
 import org.apache.tools.ant.BuildException;

--- a/src/main/java/com/threerings/getdown/tools/DigesterTask.java
+++ b/src/main/java/com/threerings/getdown/tools/DigesterTask.java
@@ -13,40 +13,34 @@ import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Task;
 
 /**
- * An ant task used to create a <code>digest.txt</code> for a Getdown
- * application deployment.
+ * An ant task used to create a <code>digest.txt</code> for a Getdown application deployment.
  */
-public class DigesterTask extends Task
-{
+public class DigesterTask extends Task {
     /**
      * Sets the application directory.
      */
-    public void setAppdir (File appdir)
-    {
+    public void setAppdir(File appdir) {
         _appdir = appdir;
     }
 
     /**
      * Sets the digest signing keystore.
      */
-    public void setKeystore (File path)
-    {
+    public void setKeystore(File path) {
         _storepath = path;
     }
 
     /**
      * Sets the keystore decryption key.
      */
-    public void setStorepass (String password)
-    {
+    public void setStorepass(String password) {
         _storepass = password;
     }
 
     /**
      * Sets the private key alias.
      */
-    public void setAlias (String alias)
-    {
+    public void setAlias(String alias) {
         _storealias = alias;
     }
 
@@ -54,12 +48,11 @@ public class DigesterTask extends Task
      * Performs the actual work of the task.
      */
     @Override
-    public void execute () throws BuildException
-    {
+    public void execute() throws BuildException {
         // make sure appdir is set
         if (_appdir == null) {
-            throw new BuildException("Must specify the path to the application directory " +
-                                     "via the 'appdir' attribute.");
+            throw new BuildException("Must specify the path to the application directory "
+                    + "via the 'appdir' attribute.");
         }
 
         // make sure _storepass and _keyalias are set, if _storepath is set

--- a/src/main/java/com/threerings/getdown/tools/DigesterTask.java
+++ b/src/main/java/com/threerings/getdown/tools/DigesterTask.java
@@ -13,7 +13,7 @@ import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Task;
 
 /**
- * An ant task used to create a <code>digest.txt</code> for a Getdown application deployment.
+ * An ant task used to create a {@code digest.txt} for a Getdown application deployment.
  */
 public class DigesterTask extends Task {
     /**

--- a/src/main/java/com/threerings/getdown/tools/JarDiff.java
+++ b/src/main/java/com/threerings/getdown/tools/JarDiff.java
@@ -41,9 +41,24 @@
 
 package com.threerings.getdown.tools;
 
-import java.io.*;
-import java.util.*;
-import java.util.jar.*;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Map;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.jar.JarOutputStream;
 
 /**
  * JarDiff is able to create a jar file containing the delta between two jar files (old and new).

--- a/src/main/java/com/threerings/getdown/tools/JarDiff.java
+++ b/src/main/java/com/threerings/getdown/tools/JarDiff.java
@@ -68,8 +68,7 @@ import java.util.jar.JarOutputStream;
  *
  * @version 1.13, 06/26/03
  */
-public class JarDiff implements JarDiffCodes
-{
+public class JarDiff implements JarDiffCodes {
     private static final int DEFAULT_READ_SIZE = 2048;
     private static byte[] newBytes = new byte[DEFAULT_READ_SIZE];
     private static byte[] oldBytes = new byte[DEFAULT_READ_SIZE];
@@ -79,16 +78,15 @@ public class JarDiff implements JarDiffCodes
     private static boolean _debug;
 
     /**
-     * Creates a patch from the two passed in files, writing the result to <code>os</code>.
+     * Creates a patch from the two passed in files, writing the result to {@code os}.
      */
-    public static void createPatch (String oldPath, String newPath,
-                                    OutputStream os, boolean minimal) throws IOException
-    {
+    public static void createPatch(String oldPath, String newPath, OutputStream os,
+            boolean minimal) throws IOException {
         JarFile2 oldJar = new JarFile2(oldPath);
         JarFile2 newJar = new JarFile2(newPath);
 
         try {
-            HashMap<String,String> moved = new HashMap<String,String>();
+            HashMap<String, String> moved = new HashMap<String, String>();
             HashSet<String> implicit = new HashSet<String>();
             HashSet<String> moveSrc = new HashSet<String>();
             HashSet<String> newEntries = new HashSet<String>();
@@ -108,7 +106,7 @@ public class JarDiff implements JarDiffCodes
                 if (oldname == null) {
                     // New or modified entry
                     if (_debug) {
-                        System.out.println("NEW: "+ newname);
+                        System.out.println("NEW: " + newname);
                     }
                     newEntries.add(newname);
                 } else {
@@ -129,15 +127,14 @@ public class JarDiff implements JarDiffCodes
                         // instead add the target as a new file.  This way
                         // the jardiff can be applied by 1.0.1/1.0
                         // JarDiffPatcher also.
-                        if (!minimal && (implicit.contains(oldname) ||
-                                         moveSrc.contains(oldname) )) {
+                        if (!minimal && (implicit.contains(oldname)
+                                || moveSrc.contains(oldname))) {
 
                             // generate non-minimal jardiff
                             // for backward compatibility
 
                             if (_debug) {
-
-                                System.out.println("NEW: "+ newname);
+                                System.out.println("NEW: " + newname);
                             }
                             newEntries.add(newname);
                         } else {
@@ -183,7 +180,7 @@ public class JarDiff implements JarDiffCodes
             if (_debug) {
                 //DEBUG:  print out moved map
                 System.out.println("MOVED MAP!!!");
-                for (Map.Entry<String,String> entry : moved.entrySet()) {
+                for (Map.Entry<String, String> entry : moved.entrySet()) {
                     System.out.println(entry);
                 }
 
@@ -208,10 +205,8 @@ public class JarDiff implements JarDiffCodes
             }
 
             jos.finish();
-//            jos.close();
-
-        } catch (IOException ioE){
-            throw ioE;
+        } catch (IOException e) {
+            throw e;
         } finally {
             try {
                 oldJar.getJarFile().close();
@@ -223,18 +218,15 @@ public class JarDiff implements JarDiffCodes
             } catch (IOException e1) {
                 //ignore
             }
-        } // finally
+        }
     }
 
     /**
-     * Writes the index file out to <code>jos</code>.
-     * <code>oldEntries</code> gives the names of the files that were removed,
-     * <code>movedMap</code> maps from the new name to the old name.
+     * Writes the index file out to {@code jos}. {@code oldEntries} gives the names of the
+     * files that were removed, {@code movedMap} maps from the new name to the old name.
      */
-    private static void createIndex (JarOutputStream jos, List<String> oldEntries,
-                                     Map<String,String> movedMap)
-        throws IOException
-    {
+    private static void createIndex(JarOutputStream jos, List<String> oldEntries,
+            Map<String, String> movedMap) throws IOException {
         StringWriter writer = new StringWriter();
 
         writer.write(VERSION_HEADER);
@@ -267,9 +259,7 @@ public class JarDiff implements JarDiffCodes
         jos.write(bytes, 0, bytes.length);
     }
 
-    private static void writeEscapedString (Writer writer, String string)
-        throws IOException
-    {
+    private static void writeEscapedString(Writer writer, String string) throws IOException {
         int index = 0;
         int last = 0;
         char[] chars = null;
@@ -287,22 +277,19 @@ public class JarDiff implements JarDiffCodes
         }
         if (last != 0) {
             writer.write(chars, last, chars.length - last);
-        }
-        else {
+        } else {
             // no spaces
             writer.write(string);
         }
     }
 
-    private static void writeEntry (JarOutputStream jos, JarEntry entry, JarFile2 file)
-        throws IOException
-    {
+    private static void writeEntry(JarOutputStream jos, JarEntry entry, JarFile2 file)
+            throws IOException {
         writeEntry(jos, entry, file.getJarFile().getInputStream(entry));
     }
 
-    private static void writeEntry (JarOutputStream jos, JarEntry entry, InputStream data)
-        throws IOException
-    {
+    private static void writeEntry(JarOutputStream jos, JarEntry entry, InputStream data)
+            throws IOException {
         jos.putNextEntry(entry);
 
         try {
@@ -313,64 +300,62 @@ public class JarDiff implements JarDiffCodes
                 jos.write(newBytes, 0, size);
                 size = data.read(newBytes);
             }
-        } catch(IOException ioE) {
-            throw ioE;
+        } catch (IOException e) {
+            throw e;
         } finally {
             try {
                 data.close();
             } catch(IOException e){
                 //Ignore
             }
-
         }
     }
 
     /**
      * JarFile2 wraps a JarFile providing some convenience methods.
      */
-    private static class JarFile2 implements Iterable<JarEntry>
-    {
+    private static class JarFile2 implements Iterable<JarEntry> {
         private JarFile _jar;
         private List<JarEntry> _entries;
-        private HashMap<String,JarEntry> _nameToEntryMap;
+        private HashMap<String, JarEntry> _nameToEntryMap;
         private HashMap<Long,LinkedList<JarEntry>> _crcToEntryMap;
 
-        public JarFile2 (String path) throws IOException {
+        public JarFile2(String path) throws IOException {
             _jar = new JarFile(new File(path));
             index();
         }
 
-        public JarFile getJarFile () {
+        public JarFile getJarFile() {
             return _jar;
         }
 
-        // from interface Iterable<JarEntry>
-        public Iterator<JarEntry> iterator () {
+        @Override
+        public Iterator<JarEntry> iterator() {
             return _entries.iterator();
         }
 
-        public JarEntry getEntryByName (String name) {
+        public JarEntry getEntryByName(String name) {
             return _nameToEntryMap.get(name);
         }
 
         /**
          * Returns true if the two InputStreams differ.
          */
-        private static boolean differs (InputStream oldIS, InputStream newIS) throws IOException {
+        private static boolean differs(InputStream oldIS, InputStream newIS) throws IOException {
             int newSize = 0;
             int oldSize;
             int total = 0;
             boolean retVal = false;
 
-            try{
+            try {
                 while (newSize != -1) {
                     newSize = newIS.read(newBytes);
                     oldSize = oldIS.read(oldBytes);
 
                     if (newSize != oldSize) {
                         if (_debug) {
-                            System.out.println("\tread sizes differ: " + newSize +
-                                               " " + oldSize + " total " + total);
+                            System.out.println("\tread sizes differ: " + newSize
+                                    + " " + oldSize + " total " + total);
                         }
                         retVal = true;
                         break;
@@ -386,7 +371,7 @@ public class JarDiff implements JarDiffCodes
                                 retVal = true;
                                 break;
                             }
-                            if ( retVal ) {
+                            if (retVal) {
                                 //Jump out
                                 break;
                             }
@@ -394,12 +379,12 @@ public class JarDiff implements JarDiffCodes
                         }
                     }
                 }
-            } catch(IOException ioE){
-                throw ioE;
+            } catch (IOException e){
+                throw e;
             } finally {
                 try {
                     oldIS.close();
-                } catch(IOException e){
+                } catch (IOException e){
                     //Ignore
                 }
                 try {
@@ -411,27 +396,28 @@ public class JarDiff implements JarDiffCodes
             return retVal;
         }
 
-        public String getBestMatch (JarFile2 file, JarEntry entry) throws IOException {
+        public String getBestMatch(JarFile2 file, JarEntry entry) throws IOException {
             // check for same name and same content, return name if found
             if (contains(file, entry)) {
-                return (entry.getName());
+                return entry.getName();
             }
 
             // return name of same content file or null
-            return (hasSameContent(file,entry));
+            return hasSameContent(file, entry);
         }
 
-        public boolean contains (JarFile2 f, JarEntry e) throws IOException {
-
+        public boolean contains(JarFile2 f, JarEntry e) throws IOException {
             JarEntry thisEntry = getEntryByName(e.getName());
 
             // Look up name in 'this' Jar2File - if not exist return false
-            if (thisEntry == null)
+            if (thisEntry == null) {
                 return false;
+            }
 
             // Check CRC - if no match - return false
-            if (thisEntry.getCrc() != e.getCrc())
+            if (thisEntry.getCrc() != e.getCrc()) {
                 return false;
+            }
 
             // Check contents - if no match - return false
             InputStream oldIS = getJarFile().getInputStream(thisEntry);
@@ -441,7 +427,7 @@ public class JarDiff implements JarDiffCodes
             return !retValue;
         }
 
-        public String hasSameContent (JarFile2 file, JarEntry entry) throws IOException {
+        public String hasSameContent(JarFile2 file, JarEntry entry) throws IOException {
             String thisName = null;
             Long crcL = new Long(entry.getCrc());
             // check if this jar contains files with the passed in entry's crc
@@ -464,11 +450,11 @@ public class JarDiff implements JarDiffCodes
             return thisName;
         }
 
-        private void index () throws IOException {
+        private void index() throws IOException {
             Enumeration<JarEntry> entries = _jar.entries();
 
-            _nameToEntryMap = new HashMap<String,JarEntry>();
-            _crcToEntryMap = new HashMap<Long,LinkedList<JarEntry>>();
+            _nameToEntryMap = new HashMap<String, JarEntry>();
+            _crcToEntryMap = new HashMap<Long, LinkedList<JarEntry>>();
             _entries = new ArrayList<JarEntry>();
             if (_debug) {
                 System.out.println("indexing: " + _jar.getName());

--- a/src/main/java/com/threerings/getdown/tools/JarDiffCodes.java
+++ b/src/main/java/com/threerings/getdown/tools/JarDiffCodes.java
@@ -8,8 +8,7 @@ package com.threerings.getdown.tools;
 /**
  * Constants shared by {@link JarDiff} and {@link JarDiffPatcher}.
  */
-public interface JarDiffCodes
-{
+public interface JarDiffCodes {
     /** The name of the jardiff control file. */
     String INDEX_NAME = "META-INF/INDEX.JD";
 

--- a/src/main/java/com/threerings/getdown/tools/JarDiffPatcher.java
+++ b/src/main/java/com/threerings/getdown/tools/JarDiffPatcher.java
@@ -11,7 +11,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.LineNumberReader;
-
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -20,7 +19,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.jar.JarOutputStream;

--- a/src/main/java/com/threerings/getdown/tools/JarDiffPatcher.java
+++ b/src/main/java/com/threerings/getdown/tools/JarDiffPatcher.java
@@ -29,8 +29,7 @@ import com.threerings.getdown.util.ProgressObserver;
 /**
  * Applies a jardiff patch to a jar file.
  */
-public class JarDiffPatcher implements JarDiffCodes
-{
+public class JarDiffPatcher implements JarDiffCodes {
     /**
      * Patches the specified jar file using the supplied patch file and writing
      * the new jar file to the supplied target.
@@ -42,9 +41,8 @@ public class JarDiffPatcher implements JarDiffCodes
      *
      * @throws IOException if any problem occurs during patching.
      */
-    public void patchJar (String jarPath, String diffPath, File target, ProgressObserver observer)
-        throws IOException
-    {
+    public void patchJar(String jarPath, String diffPath, File target, ProgressObserver observer)
+            throws IOException {
         File oldFile = new File(jarPath), diffFile = new File(diffPath);
         JarOutputStream jos = null;
         JarFile oldJar = null, jarDiff = null;
@@ -165,17 +163,14 @@ public class JarDiffPatcher implements JarDiffCodes
         }
     }
 
-    protected void updateObserver (ProgressObserver observer, double currentSize, double size)
-    {
+    protected void updateObserver(ProgressObserver observer, double currentSize, double size) {
         if (observer != null) {
-            observer.progress((int)(100*currentSize/size));
+            observer.progress((int) (100 * currentSize / size));
         }
     }
 
-    protected void determineNameMapping (
-        JarFile jarDiff, Set<String> ignoreSet, Map<String, String> renameMap)
-        throws IOException
-    {
+    protected void determineNameMapping(JarFile jarDiff, Set<String> ignoreSet,
+            Map<String, String> renameMap) throws IOException {
         InputStream is = jarDiff.getInputStream(jarDiff.getEntry(INDEX_NAME));
         if (is == null) {
             throw new IOException("error.noindex");
@@ -217,15 +212,13 @@ public class JarDiffPatcher implements JarDiffCodes
         }
     }
 
-    protected List<String> getSubpaths (String path)
-    {
+    protected List<String> getSubpaths(String path) {
         int index = 0;
         int length = path.length();
         ArrayList<String> sub = new ArrayList<String>();
 
         while (index < length) {
-            while (index < length && Character.isWhitespace
-                   (path.charAt(index))) {
+            while (index < length && Character.isWhitespace(path.charAt(index))) {
                 index++;
             }
             if (index < length) {
@@ -235,7 +228,7 @@ public class JarDiffPatcher implements JarDiffCodes
 
                 while (index < length) {
                     char aChar = path.charAt(index);
-                    if (aChar == '\\' && (index + 1) < length &&
+                    if (aChar == '\\' && index + 1 < length &&
                         path.charAt(index + 1) == ' ') {
 
                         if (subString == null) {
@@ -262,17 +255,13 @@ public class JarDiffPatcher implements JarDiffCodes
         return sub;
     }
 
-    protected void writeEntry (
-        JarOutputStream jos, JarEntry entry, JarFile file)
-        throws IOException
-    {
+    protected void writeEntry(JarOutputStream jos, JarEntry entry, JarFile file)
+            throws IOException {
         writeEntry(jos, entry, file.getInputStream(entry));
     }
 
-    protected void writeEntry (
-        JarOutputStream jos, JarEntry entry, InputStream data)
-        throws IOException
-    {
+    protected void writeEntry(JarOutputStream jos, JarEntry entry, InputStream data)
+            throws IOException {
         jos.putNextEntry(new JarEntry(entry.getName()));
 
         // Read the entry
@@ -284,7 +273,7 @@ public class JarDiffPatcher implements JarDiffCodes
         data.close();
     }
 
-    private static void closeFile (JarFile jar) {
+    private static void closeFile(JarFile jar) {
         if (jar != null) {
             try {
                 jar.close();

--- a/src/main/java/com/threerings/getdown/tools/Patcher.java
+++ b/src/main/java/com/threerings/getdown/tools/Patcher.java
@@ -5,22 +5,20 @@
 
 package com.threerings.getdown.tools;
 
+import static com.threerings.getdown.Log.log;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-
 import java.util.Enumeration;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.zip.ZipEntry;
 
 import com.samskivert.io.StreamUtil;
-
 import com.threerings.getdown.util.FileUtil;
 import com.threerings.getdown.util.ProgressObserver;
-
-import static com.threerings.getdown.Log.log;
 
 /**
  * Applies a unified patch file to an application directory, providing

--- a/src/main/java/com/threerings/getdown/tools/Patcher.java
+++ b/src/main/java/com/threerings/getdown/tools/Patcher.java
@@ -21,10 +21,9 @@ import com.threerings.getdown.util.FileUtil;
 import com.threerings.getdown.util.ProgressObserver;
 
 /**
- * Applies a unified patch file to an application directory, providing
- * percentage completion feedback along the way. <em>Note:</em> the
- * patcher is not thread safe. Create a separate patcher instance for each
- * patching action that is desired.
+ * Applies a unified patch file to an application directory, providing percentage completion
+ * feedback along the way. <em>Note:</em> the patcher is not thread safe. Create a separate patcher
+ * instance for each patching action that is desired.
  */
 public class Patcher {
     /** A suffix appended to file names to indicate that a file should be newly created. */
@@ -35,6 +34,12 @@ public class Patcher {
 
     /** A suffix appended to file names to indicate that a file should be deleted. */
     public static final String DELETE = ".delete";
+
+    protected static final int COPY_BUFFER_SIZE = 4096;
+
+    protected ProgressObserver _obs;
+    protected long _complete, _plength;
+    protected byte[] _buffer;
 
     /**
      * Applies the specified patch file to the application living in the
@@ -200,10 +205,4 @@ public class Patcher {
             System.exit(-1);
         }
     }
-
-    protected ProgressObserver _obs;
-    protected long _complete, _plength;
-    protected byte[] _buffer;
-
-    protected static final int COPY_BUFFER_SIZE = 4096;
 }

--- a/src/main/java/com/threerings/getdown/tools/Patcher.java
+++ b/src/main/java/com/threerings/getdown/tools/Patcher.java
@@ -26,8 +26,7 @@ import com.threerings.getdown.util.ProgressObserver;
  * patcher is not thread safe. Create a separate patcher instance for each
  * patching action that is desired.
  */
-public class Patcher
-{
+public class Patcher {
     /** A suffix appended to file names to indicate that a file should be newly created. */
     public static final String CREATE = ".create";
 
@@ -47,15 +46,13 @@ public class Patcher
      * with the patcher so that the user interface is not blocked for the
      * duration of the patch.
      */
-    public void patch (File appdir, File patch, ProgressObserver obs)
-        throws IOException
-    {
+    public void patch(File appdir, File patch, ProgressObserver obs) throws IOException {
         // save this information for later
         _obs = obs;
         _plength = patch.length();
 
         JarFile file = new JarFile(patch);
-        Enumeration<JarEntry> entries = file.entries(); // old skool!
+        Enumeration<JarEntry> entries = file.entries();
         while (entries.hasMoreElements()) {
             JarEntry entry = entries.nextElement();
             String path = entry.getName();
@@ -90,13 +87,11 @@ public class Patcher
         file.close();
     }
 
-    protected String strip (String path, String suffix)
-    {
+    protected String strip(String path, String suffix) {
         return path.substring(0, path.length() - suffix.length());
     }
 
-    protected void createFile (JarFile file, ZipEntry entry, File target)
-    {
+    protected void createFile(JarFile file, ZipEntry entry, File target) {
         // create our copy buffer if necessary
         if (_buffer == null) {
             _buffer = new byte[COPY_BUFFER_SIZE];
@@ -129,9 +124,7 @@ public class Patcher
         }
     }
 
-    protected void patchFile (JarFile file, ZipEntry entry,
-                              File appdir, String path)
-    {
+    protected void patchFile(JarFile file, ZipEntry entry, File appdir, String path) {
         File target = new File(appdir, path);
         File patch = new File(appdir, entry.getName());
         File otarget = new File(appdir, path + ".old");
@@ -157,8 +150,9 @@ public class Patcher
             // we'll need this to pass progress along to our observer
             final long elength = entry.getCompressedSize();
             ProgressObserver obs = new ProgressObserver() {
-                public void progress (int percent) {
-                    updateProgress((int)(percent * elength / 100));
+                @Override
+                public void progress(int percent) {
+                    updateProgress((int) (percent * elength / 100));
                 }
             };
 
@@ -186,15 +180,13 @@ public class Patcher
         }
     }
 
-    protected void updateProgress (int progress)
-    {
+    protected void updateProgress(int progress) {
         if (_obs != null) {
             _obs.progress((int)(100 * (_complete + progress) / _plength));
         }
     }
 
-    public static void main (String[] args)
-    {
+    public static void main(String[] args) {
         if (args.length != 2) {
             System.err.println("Usage: Patcher appdir patch_file");
             System.exit(-1);

--- a/src/main/java/com/threerings/getdown/util/ConfigUtil.java
+++ b/src/main/java/com/threerings/getdown/util/ConfigUtil.java
@@ -23,8 +23,7 @@ import com.samskivert.util.StringUtil;
  * Parses a file containing key/value pairs and returns a {@link HashMap} with the values. Keys may
  * be repeated, in which case they will be made to reference an array of values.
  */
-public class ConfigUtil
-{
+public class ConfigUtil {
     /**
      * Parses a configuration file containing key/value pairs. The file must be in the UTF-8
      * encoding.
@@ -35,9 +34,7 @@ public class ConfigUtil
      * @return a list of <code>String[]</code> instances containing the key/value pairs in the
      * order they were parsed from the file.
      */
-    public static List<String[]> parsePairs (File config, boolean checkPlatform)
-        throws IOException
-    {
+    public static List<String[]> parsePairs(File config, boolean checkPlatform) throws IOException {
         // annoyingly FileReader does not allow encoding to be specified (uses platform default)
         return parsePairs(
             new InputStreamReader(new FileInputStream(config), "UTF-8"), checkPlatform);
@@ -46,9 +43,8 @@ public class ConfigUtil
     /**
      * See {@link #parsePairs(File,boolean)}.
      */
-    public static List<String[]> parsePairs (Reader config, boolean checkPlatform)
-        throws IOException
-    {
+    public static List<String[]> parsePairs(Reader config, boolean checkPlatform)
+            throws IOException {
         return parsePairs(
             config,
             checkPlatform ? StringUtil.deNull(System.getProperty("os.name")).toLowerCase() : null,
@@ -62,9 +58,8 @@ public class ConfigUtil
      * @return a map from keys to values, where a value will be an array of strings if more than
      * one key/value pair in the config file was associated with the same key.
      */
-    public static Map<String, Object> parseConfig (File config, boolean checkPlatform)
-        throws IOException
-    {
+    public static Map<String, Object> parseConfig(File config, boolean checkPlatform)
+            throws IOException {
         Map<String, Object> data = new HashMap<String, Object>();
 
         // I thought that we could use HashMap<String, String[]> and put new String[] {pair[1]} for
@@ -75,7 +70,7 @@ public class ConfigUtil
             if (value == null) {
                 data.put(pair[0], pair[1]);
             } else if (value instanceof String) {
-                data.put(pair[0], new String[] { (String)value, pair[1] });
+                data.put(pair[0], new String[] { (String) value, pair[1] });
             } else if (value instanceof String[]) {
                 String[] values = (String[])value;
                 String[] nvalues = new String[values.length+1];
@@ -92,20 +87,18 @@ public class ConfigUtil
      * Massages a single string into an array and leaves existing array values as is. Simplifies
      * access to parameters that are expected to be arrays.
      */
-    public static String[] getMultiValue (Map<String, Object> data, String name)
-    {
+    public static String[] getMultiValue(Map<String, Object> data, String name) {
         Object value = data.get(name);
         if (value instanceof String) {
-            return new String[] { (String)value };
+            return new String[] { (String) value };
         } else {
-            return (String[])value;
+            return (String[]) value;
         }
     }
 
     /** A helper function for {@link #parsePairs(Reader,boolean}. */
-    protected static List<String[]> parsePairs (Reader config, String osname, String osarch)
-        throws IOException
-    {
+    protected static List<String[]> parsePairs(Reader config, String osname, String osarch)
+            throws IOException {
         List<String[]> pairs = new ArrayList<String[]>();
         for (String line : FileUtil.readLines(config)) {
             // nix comments
@@ -125,7 +118,7 @@ public class ConfigUtil
             int eidx = line.indexOf("=");
             if (eidx != -1) {
                 pair[0] = line.substring(0, eidx).trim();
-                pair[1] = line.substring(eidx+1).trim();
+                pair[1] = line.substring(eidx + 1).trim();
             } else {
                 pair[0] = line;
                 pair[1] = "";
@@ -146,7 +139,7 @@ public class ConfigUtil
                     continue;
                 }
                 // otherwise filter out the qualifier text
-                pair[1] = pair[1].substring(qidx+1).trim();
+                pair[1] = pair[1].substring(qidx + 1).trim();
             }
 
             pairs.add(pair);
@@ -166,29 +159,31 @@ public class ConfigUtil
      * Examples: [linux-amd64,linux-x86_64], [windows], [mac os x], [!windows]. Negative qualifiers
      * must appear alone, they cannot be used with other qualifiers (positive or negative).
      */
-    protected static boolean checkQualifiers (String quals, String osname, String osarch)
-    {
+    protected static boolean checkQualifiers(String quals, String osname, String osarch) {
         if (quals.startsWith("!")) {
-            if (quals.indexOf(",") != -1) { // sanity check
-                log.warning("Multiple qualifiers cannot be used when one of the qualifiers " +
-                            "is negative", "quals", quals);
+            // sanity check
+            if (quals.indexOf(",") != -1) {
+                log.warning("Multiple qualifiers cannot be used when one of the qualifiers "
+                        + "is negative", "quals", quals);
                 return false;
             }
             return !checkQualifier(quals.substring(1), osname, osarch);
         }
         for (String qual : quals.split(",")) {
             if (checkQualifier(qual, osname, osarch)) {
-                return true; // if we have a positive match, we can immediately return true
+                // if we have a positive match, we can immediately return true
+                return true;
             }
         }
-        return false; // we had no positive matches, so return false
+
+        // we had no positive matches, so return false
+        return false;
     }
 
     /** A helper function for {@link #checkQualifiers}. */
-    protected static boolean checkQualifier (String qual, String osname, String osarch)
-    {
+    protected static boolean checkQualifier(String qual, String osname, String osarch) {
         String[] bits = qual.trim().toLowerCase().split("-");
-        String os = bits[0], arch = (bits.length > 1) ? bits[1] : "";
-        return (osname.indexOf(os) != -1) && (osarch.indexOf(arch) != -1);
+        String os = bits[0], arch = bits.length > 1 ? bits[1] : "";
+        return osname.indexOf(os) != -1 && osarch.indexOf(arch) != -1;
     }
 }

--- a/src/main/java/com/threerings/getdown/util/ConfigUtil.java
+++ b/src/main/java/com/threerings/getdown/util/ConfigUtil.java
@@ -5,20 +5,19 @@
 
 package com.threerings.getdown.util;
 
+import static com.threerings.getdown.Log.log;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import com.samskivert.util.StringUtil;
-
-import static com.threerings.getdown.Log.log;
 
 /**
  * Parses a file containing key/value pairs and returns a {@link HashMap} with the values. Keys may

--- a/src/main/java/com/threerings/getdown/util/ConnectionUtil.java
+++ b/src/main/java/com/threerings/getdown/util/ConnectionUtil.java
@@ -13,14 +13,11 @@ import java.net.URLDecoder;
 
 import org.apache.commons.codec.binary.Base64;
 
-public class ConnectionUtil
-{
+public class ConnectionUtil {
     /**
      * Opens a connection to a URL, setting the authentication header if user info is present.
      */
-    public static URLConnection open (URL url)
-        throws IOException
-    {
+    public static URLConnection open(URL url) throws IOException {
         URLConnection conn = url.openConnection();
 
         // If URL has a username:password@ before hostname, use HTTP basic auth
@@ -29,8 +26,9 @@ public class ConnectionUtil
             // Remove any percent-encoding in the username/password
             userInfo = URLDecoder.decode(userInfo, "UTF-8");
             // Now base64 encode the auth info and make it a single line
-            String encoded = Base64.encodeBase64String(userInfo.getBytes("UTF-8")).
-                replaceAll("\\n","").replaceAll("\\r", "");
+            String encoded = Base64.encodeBase64String(userInfo.getBytes("UTF-8"))
+                .replaceAll("\\n","")
+                .replaceAll("\\r", "");
             conn.setRequestProperty("Authorization", "Basic " + encoded);
         }
 
@@ -41,9 +39,7 @@ public class ConnectionUtil
      * Opens a connection to a http or https URL, setting the authentication header if user info
      * is present. Throws a class cast exception if the connection returned is not the right type.
      */
-    public static HttpURLConnection openHttp (URL url)
-        throws IOException
-    {
-        return (HttpURLConnection)open(url);
+    public static HttpURLConnection openHttp(URL url) throws IOException {
+        return (HttpURLConnection) open(url);
     }
 }

--- a/src/main/java/com/threerings/getdown/util/FileUtil.java
+++ b/src/main/java/com/threerings/getdown/util/FileUtil.java
@@ -5,7 +5,15 @@
 
 package com.threerings.getdown.util;
 
-import java.io.*;
+import static com.threerings.getdown.Log.log;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.jar.JarOutputStream;
@@ -13,8 +21,6 @@ import java.util.jar.Pack200;
 import java.util.zip.GZIPInputStream;
 
 import com.samskivert.io.StreamUtil;
-
-import static com.threerings.getdown.Log.log;
 
 /**
  * File related utilities.

--- a/src/main/java/com/threerings/getdown/util/FileUtil.java
+++ b/src/main/java/com/threerings/getdown/util/FileUtil.java
@@ -25,16 +25,14 @@ import com.samskivert.io.StreamUtil;
 /**
  * File related utilities.
  */
-public class FileUtil extends com.samskivert.util.FileUtil
-{
+public class FileUtil extends com.samskivert.util.FileUtil {
     /**
      * Gets the specified source file to the specified destination file by hook or crook. Windows
      * has all sorts of problems which we work around in this method.
      *
      * @return true if we managed to get the job done, false otherwise.
      */
-    public static boolean renameTo (File source, File dest)
-    {
+    public static boolean renameTo(File source, File dest) {
         // if we're on a civilized operating system we may be able to simple rename it
         if (source.renameTo(dest)) {
             return true;
@@ -64,8 +62,8 @@ public class FileUtil extends com.samskivert.util.FileUtil
             fout = new FileOutputStream(dest);
             StreamUtil.copy(fin, fout);
             if (!source.delete()) {
-                log.warning("Failed to delete " + source +
-                            " after brute force copy to " + dest + ".");
+                log.warning("Failed to delete " + source
+                        + " after brute force copy to " + dest + ".");
             }
             return true;
 
@@ -83,9 +81,7 @@ public class FileUtil extends com.samskivert.util.FileUtil
      * Reads the contents of the supplied input stream into a list of lines. Closes the reader on
      * successful or failed completion.
      */
-    public static List<String> readLines (Reader in)
-        throws IOException
-    {
+    public static List<String> readLines(Reader in) throws IOException {
         List<String> lines = new ArrayList<String>();
         try {
             BufferedReader bin = new BufferedReader(in);
@@ -100,8 +96,7 @@ public class FileUtil extends com.samskivert.util.FileUtil
      * Unpacks a pack200 packed jar file from {@code packedJar} into {@code target}. If {@code
      * packedJar} has a {@code .gz} extension, it will be gunzipped first.
      */
-    public static boolean unpackPacked200Jar (File packedJar, File target)
-    {
+    public static boolean unpackPacked200Jar(File packedJar, File target) {
         InputStream packedJarIn = null;
         FileOutputStream extractedJarFileOut = null;
         JarOutputStream jarOutputStream = null;

--- a/src/main/java/com/threerings/getdown/util/LaunchUtil.java
+++ b/src/main/java/com/threerings/getdown/util/LaunchUtil.java
@@ -5,16 +5,17 @@
 
 package com.threerings.getdown.util;
 
+import static com.threerings.getdown.Log.log;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
+
 import com.samskivert.io.StreamUtil;
 import com.samskivert.util.RunAnywhere;
 import com.samskivert.util.StringUtil;
-
-import static com.threerings.getdown.Log.log;
 
 /**
  * Useful routines for launching Java applications from within other Java

--- a/src/main/java/com/threerings/getdown/util/LaunchUtil.java
+++ b/src/main/java/com/threerings/getdown/util/LaunchUtil.java
@@ -18,11 +18,9 @@ import com.samskivert.util.RunAnywhere;
 import com.samskivert.util.StringUtil;
 
 /**
- * Useful routines for launching Java applications from within other Java
- * applications.
+ * Useful routines for launching Java applications from within other Java applications.
  */
-public class LaunchUtil
-{
+public class LaunchUtil {
     /** The directory into which a local VM installation should be unpacked. */
     public static final String LOCAL_JAVA_DIR = "java_vm";
 
@@ -48,10 +46,8 @@ public class LaunchUtil
      * Getdown will not cause the application to be upgraded, so the application will have to
      * resort to telling the user that it is in a bad way.
      */
-    public static boolean updateVersionAndRelaunch (
-            File appdir, String getdownJarName, String newVersion)
-        throws IOException
-    {
+    public static boolean updateVersionAndRelaunch(File appdir, String getdownJarName,
+            String newVersion) throws IOException {
         // create the file that instructs Getdown to upgrade
         File vfile = new File(appdir, "version.txt");
         PrintStream ps = new PrintStream(new FileOutputStream(vfile));
@@ -81,8 +77,7 @@ public class LaunchUtil
     /**
      * Reconstructs the path to the JVM used to launch this process.
      */
-    public static String getJVMPath (File appdir)
-    {
+    public static String getJVMPath(File appdir) {
         return getJVMPath(appdir, false);
     }
 
@@ -91,8 +86,7 @@ public class LaunchUtil
      *
      * @param windebug if true we will use java.exe instead of javaw.exe on Windows.
      */
-    public static String getJVMPath (File appdir, boolean windebug)
-    {
+    public static String getJVMPath(File appdir, boolean windebug) {
         // first look in our application directory for an installed VM
         String vmpath = checkJVMPath(new File(appdir, LOCAL_JAVA_DIR).getPath(), windebug);
 
@@ -133,8 +127,7 @@ public class LaunchUtil
      * <p> If the upgrade fails for a variety of reasons, warnings are logged but no other actions
      * are taken. There's not much else one can do other than try again next time around.
      */
-    public static void upgradeGetdown (File oldgd, File curgd, File newgd)
-    {
+    public static void upgradeGetdown(File oldgd, File curgd, File newgd) {
         // we assume getdown's jar file size changes with every upgrade, this is not guaranteed,
         // but in reality it will, and it allows us to avoid pointlessly upgrading getdown every
         // time the client is updated which is unnecessarily flirting with danger
@@ -183,17 +176,15 @@ public class LaunchUtil
      * Returns true if, on this operating system, we have to stick around and read the stderr from
      * our children processes to prevent them from filling their output buffers and hanging.
      */
-    public static boolean mustMonitorChildren ()
-    {
+    public static boolean mustMonitorChildren() {
         String osname = System.getProperty("os.name").toLowerCase();
-        return (osname.indexOf("windows 98") != -1 || osname.indexOf("windows me") != -1);
+        return osname.indexOf("windows 98") != -1 || osname.indexOf("windows me") != -1;
     }
 
     /**
      * Checks whether a Java Virtual Machine can be located in the supplied path.
      */
-    protected static String checkJVMPath (String vmhome, boolean windebug)
-    {
+    protected static String checkJVMPath(String vmhome, boolean windebug) {
         String vmbase = vmhome + File.separator + "bin" + File.separator;
         String vmpath = vmbase + "java";
         if (new File(vmpath).exists()) {

--- a/src/main/java/com/threerings/getdown/util/ProgressAggregator.java
+++ b/src/main/java/com/threerings/getdown/util/ProgressAggregator.java
@@ -9,38 +9,40 @@ package com.threerings.getdown.util;
  * Accumulates the progress from a number of (potentially parallel) elements into a single smoothly
  * progressing progress.
  */
-public class ProgressAggregator
-{
-    public ProgressAggregator (ProgressObserver target, long[] sizes) {
+public class ProgressAggregator {
+    public ProgressAggregator(ProgressObserver target, long[] sizes) {
         _target = target;
         _sizes = sizes;
         _progress = new int[sizes.length];
     }
 
-    public ProgressObserver startElement (final int index) {
+    public ProgressObserver startElement(final int index) {
         return new ProgressObserver() {
-            public void progress (int percent) {
+            @Override
+            public void progress(int percent) {
                 _sizes[index] = percent;
                 updateAggProgress();
             }
         };
     }
 
-    protected void updateAggProgress () {
+    protected void updateAggProgress() {
         long totalSize = 0L, currentSize = 0L;
         synchronized (this) {
             for (int ii = 0, ll = _sizes.length; ii < ll; ii++) {
                 long size = _sizes[ii];
                 totalSize += size;
-                currentSize += (int)((size * _progress[ii])/100.0);
+                currentSize += (int) (size * _progress[ii] / 100.0);
             }
         }
-        _target.progress((int)(100.0*currentSize / totalSize));
+        _target.progress((int) (100.0 * currentSize / totalSize));
     }
 
-    protected static long sum (long[] sizes) {
+    protected static long sum(long[] sizes) {
         long totalSize = 0L;
-        for (long size : sizes) totalSize += size;
+        for (long size : sizes) {
+            totalSize += size;
+        }
         return totalSize;
     }
 

--- a/src/main/java/com/threerings/getdown/util/ProgressAggregator.java
+++ b/src/main/java/com/threerings/getdown/util/ProgressAggregator.java
@@ -10,6 +10,10 @@ package com.threerings.getdown.util;
  * progressing progress.
  */
 public class ProgressAggregator {
+    protected ProgressObserver _target;
+    protected long[] _sizes;
+    protected int[] _progress;
+
     public ProgressAggregator(ProgressObserver target, long[] sizes) {
         _target = target;
         _sizes = sizes;
@@ -45,8 +49,4 @@ public class ProgressAggregator {
         }
         return totalSize;
     }
-
-    protected ProgressObserver _target;
-    protected long[] _sizes;
-    protected int[] _progress;
 }

--- a/src/main/java/com/threerings/getdown/util/ProgressObserver.java
+++ b/src/main/java/com/threerings/getdown/util/ProgressObserver.java
@@ -8,11 +8,10 @@ package com.threerings.getdown.util;
 /**
  * Used to communicate progress.
  */
-public interface ProgressObserver
-{
+public interface ProgressObserver {
     /**
      * Informs the observer that we have completed the specified
      * percentage of the process.
      */
-    public void progress (int percent);
+    public void progress(int percent);
 }

--- a/src/main/java/com/threerings/getdown/util/VersionUtil.java
+++ b/src/main/java/com/threerings/getdown/util/VersionUtil.java
@@ -5,6 +5,8 @@
 
 package com.threerings.getdown.util;
 
+import static com.threerings.getdown.Log.log;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -18,9 +20,7 @@ import java.util.regex.Pattern;
 
 import com.samskivert.io.StreamUtil;
 import com.samskivert.util.StringUtil;
-
 import com.threerings.getdown.data.SysProps;
-import static com.threerings.getdown.Log.log;
 
 /**
  * Version related utilities.

--- a/src/main/java/com/threerings/getdown/util/VersionUtil.java
+++ b/src/main/java/com/threerings/getdown/util/VersionUtil.java
@@ -25,13 +25,11 @@ import com.threerings.getdown.data.SysProps;
 /**
  * Version related utilities.
  */
-public class VersionUtil
-{
+public class VersionUtil {
     /**
      * Reads a version number from a file.
      */
-    public static long readVersion (File vfile)
-    {
+    public static long readVersion(File vfile) {
         long fileVersion = -1;
         BufferedReader bin = null;
         try {
@@ -52,8 +50,7 @@ public class VersionUtil
     /**
      * Writes a version number to a file.
      */
-    public static void writeVersion (File vfile, long version) throws IOException
-    {
+    public static void writeVersion(File vfile, long version) throws IOException {
         PrintStream out = new PrintStream(new FileOutputStream(vfile));
         try {
             out.println(version);
@@ -68,15 +65,16 @@ public class VersionUtil
      * Parses {@code versStr} using {@code versRegex} into a (long) integer version number.
      * @see SysProps#parseJavaVersion
      */
-    public static long parseJavaVersion (String versRegex, String versStr)
-    {
+    public static long parseJavaVersion(String versRegex, String versStr) {
         Matcher m = Pattern.compile(versRegex).matcher(versStr);
-        if (!m.matches()) return 0L;
+        if (!m.matches()) {
+            return 0L;
+        }
 
         long vers = 0L;
         for (int ii = 1; ii <= m.groupCount(); ii++) {
             String valstr = m.group(ii);
-            int value = (valstr == null) ? 0 : parseInt(valstr);
+            int value = valstr == null ? 0 : parseInt(valstr);
             vers *= 100;
             vers += value;
         }
@@ -86,8 +84,7 @@ public class VersionUtil
     /**
      * Reads and parses the version from the {@code release} file bundled with a JVM.
      */
-    public static long readReleaseVersion (File relfile, String versRegex)
-    {
+    public static long readReleaseVersion(File relfile, String versRegex) {
         BufferedReader in = null;
         try {
             in = new BufferedReader(new FileReader(relfile));
@@ -112,13 +109,13 @@ public class VersionUtil
         }
     }
 
-    private static int parseInt (String str) {
+    private static int parseInt(String str) {
         int value = 0;
         for (int ii = 0, ll = str.length(); ii < ll; ii++) {
             char c = str.charAt(ii);
             if (c >= '0' && c <= '9') {
                 value *= 10;
-                value += (c - '0');
+                value += c - '0';
             }
         }
         return value;

--- a/src/test/java/com/threerings/getdown/data/SysPropsTest.java
+++ b/src/test/java/com/threerings/getdown/data/SysPropsTest.java
@@ -5,7 +5,7 @@
 
 package com.threerings.getdown.data;
 
-import org.junit.*;
+import org.junit.Test;
 
 public class SysPropsTest {
 

--- a/src/test/java/com/threerings/getdown/data/SysPropsTest.java
+++ b/src/test/java/com/threerings/getdown/data/SysPropsTest.java
@@ -9,12 +9,13 @@ import org.junit.Test;
 
 public class SysPropsTest {
 
-  @Test public void testParseJavaVersion () {
-    long vers = SysProps.parseJavaVersion("java.version", "(\\d+)\\.(\\d+)\\.(\\d+)(_\\d+)?");
-    assert(vers > 1060000);
+    @Test
+    public void testParseJavaVersion() {
+        long vers = SysProps.parseJavaVersion("java.version", "(\\d+)\\.(\\d+)\\.(\\d+)(_\\d+)?");
+        assert vers > 1060000;
 
-    long runVers = SysProps.parseJavaVersion("java.runtime.version",
-                                             "(\\d+)\\.(\\d+)\\.(\\d+)(_\\d+)?(-b\\d+)?");
-    assert(runVers > 106000000);
-  }
+        long runVers = SysProps.parseJavaVersion("java.runtime.version",
+                "(\\d+)\\.(\\d+)\\.(\\d+)(_\\d+)?(-b\\d+)?");
+        assert runVers > 106000000;
+    }
 }

--- a/src/test/java/com/threerings/getdown/util/ConfigUtilTest.java
+++ b/src/test/java/com/threerings/getdown/util/ConfigUtilTest.java
@@ -19,8 +19,7 @@ import com.samskivert.util.RandomUtil;
 /**
  * Tests {@link ConfigUtil}.
  */
-public class ConfigUtilTest
-{
+public class ConfigUtilTest {
     public static class Pair {
         public final String key;
         public final String value;
@@ -38,8 +37,8 @@ public class ConfigUtilTest
         new Pair("nine", "ten"),
     };
 
-    @Test public void testSimplePairs () throws IOException
-    {
+    @Test
+    public void testSimplePairs() throws IOException {
         List<String[]> pairs = ConfigUtil.parsePairs(toReader(SIMPLE_PAIRS), true);
         for (int ii = 0; ii < SIMPLE_PAIRS.length; ii++) {
             assertEquals(SIMPLE_PAIRS[ii].key, pairs.get(ii)[0]);
@@ -47,8 +46,8 @@ public class ConfigUtilTest
         }
     }
 
-    @Test public void testQualifiedPairs () throws IOException
-    {
+    @Test
+    public void testQualifiedPairs() throws IOException {
         Pair linux = new Pair("one", "[linux] two");
         Pair mac = new Pair("three", "[mac os x] four");
         Pair linuxAndMac = new Pair("five", "[linux, mac os x] six");
@@ -130,8 +129,7 @@ public class ConfigUtilTest
         assertTrue(!exists(parsed, notWin.key));
     }
 
-    protected static boolean exists (List<String[]> pairs, String key)
-    {
+    protected static boolean exists(List<String[]> pairs, String key) {
         for (String[] pair : pairs) {
             if (pair[0].equals(key)) {
                 return true;
@@ -140,8 +138,7 @@ public class ConfigUtilTest
         return false;
     }
 
-    protected static StringReader toReader (Pair[] pairs)
-    {
+    protected static StringReader toReader(Pair[] pairs) {
         StringBuilder builder = new StringBuilder();
         for (Pair pair : pairs) {
             // throw some whitespace in to ensure it's trimmed
@@ -153,8 +150,7 @@ public class ConfigUtilTest
         return new StringReader(builder.toString());
     }
 
-    protected static String whitespace ()
-    {
+    protected static String whitespace() {
         return RandomUtil.getBoolean() ? " " : "";
     }
 }

--- a/src/test/java/com/threerings/getdown/util/ConfigUtilTest.java
+++ b/src/test/java/com/threerings/getdown/util/ConfigUtilTest.java
@@ -5,14 +5,16 @@
 
 package com.threerings.getdown.util;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import java.io.IOException;
 import java.io.StringReader;
 import java.util.List;
 
-import com.samskivert.util.RandomUtil;
+import org.junit.Test;
 
-import org.junit.*;
-import static org.junit.Assert.*;
+import com.samskivert.util.RandomUtil;
 
 /**
  * Tests {@link ConfigUtil}.

--- a/src/test/java/com/threerings/getdown/util/FileUtilTest.java
+++ b/src/test/java/com/threerings/getdown/util/FileUtilTest.java
@@ -16,10 +16,9 @@ import org.junit.Test;
 /**
  * Tests {@link FileUtil}.
  */
-public class FileUtilTest
-{
-    @Test public void testReadLines () throws IOException
-    {
+public class FileUtilTest {
+    @Test
+    public void testReadLines() throws IOException {
         String data = "This is a test\nof a file with\na few lines\n";
         List<String> lines = FileUtil.readLines(new StringReader(data));
         String[] linesBySplit = data.split("\n");

--- a/src/test/java/com/threerings/getdown/util/FileUtilTest.java
+++ b/src/test/java/com/threerings/getdown/util/FileUtilTest.java
@@ -5,12 +5,13 @@
 
 package com.threerings.getdown.util;
 
+import static org.junit.Assert.assertEquals;
+
 import java.io.IOException;
 import java.io.StringReader;
 import java.util.List;
 
-import org.junit.*;
-import static org.junit.Assert.*;
+import org.junit.Test;
 
 /**
  * Tests {@link FileUtil}.


### PR DESCRIPTION
This pull request aims to apply basic Java coding conventions to Getdown. The following changes have been applied:

- **Organized Imports.** Unused imports have been removed and wildcard imports were resolved.
- Converted control statement bodies to block
- Removed unnecessary parentheses
- Comments always on a separate line
- Curly braces on the same line
- Annotations on a separate line
- Added missing overrides
- Removed space between method name and left parenthesis
- **Moved location of constants and member variables.** They are now always at the top of the class.

These are non-functional changes.