### PR TITLE
Add "Trusted-Library" manifest attribute

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -211,6 +211,7 @@
               <Codebase>*</Codebase>
               <Application-Library-Allowable-Codebase>*</Application-Library-Allowable-Codebase>
               <Caller-Allowable-Codebase>*</Caller-Allowable-Codebase>
+              <Trusted-Library>true</Trusted-Library>
             </manifestEntries>
           </archive>
         </configuration>


### PR DESCRIPTION
This pull requests adds the

    Trusted-Library: true

attribute to the `Manifest`.

I'm on 1.8.0_102 and without the attribute applied I receive `ClassNotFoundException`s in a Java Web Start/Applet environment.