### PR TITLE
A code cache to support multiple app instances

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,12 @@
       <version>4.8.1</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>1.10.19</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/com/threerings/getdown/classpath/CacheBasedClassPathBuilder.java
+++ b/src/main/java/com/threerings/getdown/classpath/CacheBasedClassPathBuilder.java
@@ -1,0 +1,61 @@
+package com.threerings.getdown.classpath;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.LinkedHashSet;
+import java.util.concurrent.TimeUnit;
+
+import com.threerings.getdown.classpath.cache.GarbageCollector;
+import com.threerings.getdown.classpath.cache.ResourceCache;
+import com.threerings.getdown.data.Application;
+import com.threerings.getdown.data.Resource;
+import com.threerings.getdown.util.file.FileWalker;
+
+/**
+ * Instead of building the class path from the application directory, this class path builder puts
+ * the files that make up the class path into a cache and assembles the class path from the cache
+ * directory.
+ */
+public class CacheBasedClassPathBuilder extends ClassPathBuilderBase
+{
+    static final String CACHE_DIR = ".cache";
+
+    public CacheBasedClassPathBuilder(Application application)
+    {
+        super(application);
+    }
+
+    @Override
+    public ClassPath buildClassPath () throws IOException
+    {
+        File cacheDir = new File(_application.getAppdir(), CACHE_DIR);
+
+        // a negative value of code_cache_retention_days allows to clean up the cache forcefully
+        if (_application.getCodeCacheRetentionDays() <= 0) {
+            runGarbageCollection(cacheDir);
+        }
+
+        ResourceCache cache = new ResourceCache(cacheDir);
+
+        LinkedHashSet<ClassPathElement> classPathEntries = new LinkedHashSet<ClassPathElement>();
+
+        for (Resource resource: _application.getActiveCodeResources()) {
+            classPathEntries.add(
+                new ClassPathElement(
+                    cache.cacheFile(resource.getFinalTarget(), _application.getDigest(resource))));
+        }
+
+        if (_application.getCodeCacheRetentionDays() > 0) {
+            runGarbageCollection(cacheDir);
+        }
+
+        return new ClassPath(classPathEntries);
+    }
+
+    private void runGarbageCollection(File cacheDir) {
+        GarbageCollector gc = new GarbageCollector(
+                new FileWalker(cacheDir), _application.getCodeCacheRetentionDays(), TimeUnit.DAYS);
+
+        gc.collectGarbage();
+    }
+}

--- a/src/main/java/com/threerings/getdown/classpath/ClassPath.java
+++ b/src/main/java/com/threerings/getdown/classpath/ClassPath.java
@@ -1,0 +1,69 @@
+package com.threerings.getdown.classpath;
+
+import java.io.File;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * Represents the class path and it's elements of the application to be launched. The class path can
+ * either be represented as an {@link #asArgumentString() argument string} for the java command line
+ * or as an {@link #asUrls() array of URLs} to be used by a {@link URLClassLoader}.
+ */
+public class ClassPath
+{
+    public ClassPath (LinkedHashSet<ClassPathElement> classPathEntries)
+    {
+        this._classPathEntries = Collections.unmodifiableSet(classPathEntries);
+    }
+
+    /**
+     * Returns the class path as an java command line argument string, e.g
+     *
+     * <pre>
+     *   /path/to/a.jar:/path/to/b.jar
+     * </pre>
+     */
+    public String asArgumentString ()
+    {
+        StringBuilder builder = new StringBuilder();
+        String delimiter = "";
+
+        for (ClassPathElement entry: _classPathEntries)
+        {
+            builder
+                .append(delimiter)
+                .append(entry.getAbsolutePath());
+
+            delimiter = File.pathSeparator;
+        }
+
+        return builder.toString();
+    }
+
+    /**
+     * Returns the class path entries as an array of URLs to be used for example by an
+     * {@link URLClassLoader}.
+     */
+    public URL[] asUrls ()
+    {
+        URL[] urls = new URL[_classPathEntries.size()];
+
+        int i = 0;
+
+        for (ClassPathElement entry : _classPathEntries) {
+            urls[i++] = entry.getURL();
+        }
+
+        return urls;
+    }
+
+    public Set<ClassPathElement> getClassPathEntries ()
+    {
+        return _classPathEntries;
+    }
+
+    private final Set<ClassPathElement> _classPathEntries;
+}

--- a/src/main/java/com/threerings/getdown/classpath/ClassPathBuilder.java
+++ b/src/main/java/com/threerings/getdown/classpath/ClassPathBuilder.java
@@ -1,0 +1,13 @@
+package com.threerings.getdown.classpath;
+
+import java.io.IOException;
+
+/**
+ * A class path builder compiles the class path of the application to be launched.
+ */
+public interface ClassPathBuilder {
+    /**
+     * Builds and returns the class path of the application to be launched.
+     */
+    ClassPath buildClassPath () throws IOException;
+}

--- a/src/main/java/com/threerings/getdown/classpath/ClassPathBuilderBase.java
+++ b/src/main/java/com/threerings/getdown/classpath/ClassPathBuilderBase.java
@@ -1,0 +1,14 @@
+package com.threerings.getdown.classpath;
+
+import com.threerings.getdown.data.Application;
+
+/**
+ * Base class for {@link ClassPathBuilder class path builders}.
+ */
+abstract class ClassPathBuilderBase implements ClassPathBuilder {
+    public ClassPathBuilderBase(Application _application) {
+        this._application = _application;
+    }
+
+    protected final Application _application;
+}

--- a/src/main/java/com/threerings/getdown/classpath/ClassPathBuilderFactory.java
+++ b/src/main/java/com/threerings/getdown/classpath/ClassPathBuilderFactory.java
@@ -1,0 +1,22 @@
+package com.threerings.getdown.classpath;
+
+import com.threerings.getdown.data.Application;
+
+/**
+ * A factory for {@link ClassPathBuilder class path builders}.
+ */
+public abstract class ClassPathBuilderFactory {
+    private ClassPathBuilderFactory () {
+    }
+
+    /**
+     * Creates a class path builder that is able to compile the class path of the supplied
+     * {@link Application application}.
+     */
+    public static ClassPathBuilder create (Application application)
+    {
+        return application.isUseCodeCache()
+                ? new CacheBasedClassPathBuilder(application)
+                        : new DefaultClassPathBuilder(application);
+    }
+}

--- a/src/main/java/com/threerings/getdown/classpath/ClassPathElement.java
+++ b/src/main/java/com/threerings/getdown/classpath/ClassPathElement.java
@@ -1,0 +1,47 @@
+package com.threerings.getdown.classpath;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+/**
+ * Represents an element of an applications class path.
+ */
+public class ClassPathElement
+{
+    public ClassPathElement (File _file)
+    {
+        this._file = _file;
+    }
+
+    /**
+     * Returns the code resource.
+     */
+    public File getFile ()
+    {
+        return _file;
+    }
+
+
+    /**
+     * Returns the elements absolute path on the file system.
+     */
+    public String getAbsolutePath ()
+    {
+        return _file.getAbsolutePath();
+    }
+
+    /**
+     * Returns the file URL of this class path element.
+     */
+    public URL getURL ()
+    {
+        try {
+            return _file.toURI().toURL();
+        } catch (MalformedURLException e) {
+            throw new IllegalStateException("URL of file is illegal: " + getAbsolutePath(), e);
+        }
+    }
+
+    private final File _file;
+}

--- a/src/main/java/com/threerings/getdown/classpath/DefaultClassPathBuilder.java
+++ b/src/main/java/com/threerings/getdown/classpath/DefaultClassPathBuilder.java
@@ -1,0 +1,30 @@
+package com.threerings.getdown.classpath;
+
+import java.util.LinkedHashSet;
+
+import com.threerings.getdown.data.Application;
+import com.threerings.getdown.data.Resource;
+
+/**
+ * The default class path builder assembles the class path from the code resources to be found in
+ * the application directory.
+ */
+public class DefaultClassPathBuilder extends ClassPathBuilderBase
+{
+    public DefaultClassPathBuilder(Application _application) {
+        super(_application);
+    }
+
+    @Override
+    public ClassPath buildClassPath ()
+    {
+        LinkedHashSet<ClassPathElement> classPathEntries = new LinkedHashSet<ClassPathElement>();
+
+        for (Resource resource: _application.getActiveCodeResources()) {
+            classPathEntries.add(new ClassPathElement(resource.getFinalTarget()));
+        }
+
+        return new ClassPath(classPathEntries);
+    }
+
+}

--- a/src/main/java/com/threerings/getdown/classpath/cache/GarbageCollector.java
+++ b/src/main/java/com/threerings/getdown/classpath/cache/GarbageCollector.java
@@ -1,0 +1,91 @@
+package com.threerings.getdown.classpath.cache;
+
+import java.io.File;
+import java.util.concurrent.TimeUnit;
+
+import com.threerings.getdown.util.file.FileVisitor;
+import com.threerings.getdown.util.file.FileWalker;
+
+/**
+ * Collects elements in the {@link ResourceCache cache} which became unused and deletes them
+ * afterwards.
+ */
+public class GarbageCollector
+{
+    public GarbageCollector (
+            FileWalker _fileWalker, int retentionPeriod, TimeUnit retentionPeriodTimeUnit)
+    {
+        this._fileWalker = _fileWalker;
+        this._retentionMillis = retentionPeriodTimeUnit.toMillis(retentionPeriod);
+    }
+
+    /**
+     * Collect and delete the garbage in the cache.
+     */
+    public void collectGarbage ()
+    {
+        _fileWalker.walkTree(new FileVisitor() {
+            @Override
+            public void visit(File file)
+            {
+                collect(file);
+            }
+        });
+    }
+
+    private void collect (File file) {
+        File cachedFile = getCachedFile(file);
+        File lastAccessedFile = getLastAccessedFile(file);
+
+        if (!cachedFile.exists() || !lastAccessedFile.exists()) {
+            if (cachedFile.exists()) {
+                cachedFile.delete();
+            } else {
+                lastAccessedFile.delete();
+            }
+        } else if (shouldDelete(lastAccessedFile)) {
+            lastAccessedFile.delete();
+            cachedFile.delete();
+        }
+
+        File folder = file.getParentFile();
+
+        if (folder.list().length == 0) {
+            folder.delete();
+        }
+    }
+
+    private boolean shouldDelete(File lastAccessedFile) {
+        return System.currentTimeMillis() - lastAccessedFile.lastModified() > _retentionMillis;
+    }
+
+    private File getLastAccessedFile (File file)
+    {
+        if (isLastAccessedFile(file)) {
+            return file;
+        }
+
+        return new File(
+                file.getParentFile(),
+                file.getName() + ResourceCache.LAST_ACCESSED_FILE_SUFFIX);
+    }
+
+    private boolean isLastAccessedFile (File file)
+    {
+        return file.getName().endsWith(ResourceCache.LAST_ACCESSED_FILE_SUFFIX);
+    }
+
+    private File getCachedFile (File file)
+    {
+        if (!isLastAccessedFile(file)) {
+            return file;
+        }
+
+        return new File(
+                file.getParentFile(),
+                file.getName().substring(0, file.getName().lastIndexOf(".")));
+    }
+
+    private final FileWalker _fileWalker;
+    private final long _retentionMillis;
+}

--- a/src/main/java/com/threerings/getdown/classpath/cache/ResourceCache.java
+++ b/src/main/java/com/threerings/getdown/classpath/cache/ResourceCache.java
@@ -1,0 +1,73 @@
+package com.threerings.getdown.classpath.cache;
+
+import java.io.File;
+import java.io.IOException;
+
+import com.threerings.getdown.util.FileUtil;
+
+/**
+ * Maintains a cache of code resources. The cache allows multiple application instances of different
+ * versions to open at the same time.
+ */
+public class ResourceCache
+{
+    public ResourceCache (File _cacheDir) throws IOException
+    {
+        this._cacheDir = _cacheDir;
+
+        createDirectoryIfNecessary(_cacheDir);
+    }
+
+    private void createDirectoryIfNecessary (File dir) throws IOException
+    {
+        if (!dir.exists() && !dir.mkdirs()) {
+            throw new IOException("unable to create directory: " + dir.getAbsolutePath());
+        }
+    }
+
+    /**
+     * Caches the given file under it's {@code digest}.
+     *
+     * @return the cached file
+     */
+    public File cacheFile (File fileToCache, String digest) throws IOException
+    {
+        File cacheLocation = new File(_cacheDir, digest.substring(0, 2));
+        createDirectoryIfNecessary(cacheLocation);
+
+        File cachedFile = new File(cacheLocation, digest + getFileSuffix(fileToCache));
+        File lastAccessedFile = new File(
+                cacheLocation, cachedFile.getName() + LAST_ACCESSED_FILE_SUFFIX);
+
+        if (!cachedFile.exists()) {
+            createNewFile(cachedFile);
+            FileUtil.copy(fileToCache, cachedFile);
+        }
+
+        if (lastAccessedFile.exists()) {
+            lastAccessedFile.setLastModified(System.currentTimeMillis());
+        } else {
+            createNewFile(lastAccessedFile);
+        }
+
+        return cachedFile;
+    }
+
+    private void createNewFile (File fileToCreate) throws IOException
+    {
+        if (!fileToCreate.exists() && !fileToCreate.createNewFile()) {
+            throw new IOException("unable to create new file: " + fileToCreate.getAbsolutePath());
+        }
+    }
+
+    private String getFileSuffix (File fileToCache) {
+        String fileName = fileToCache.getName();
+        int index = fileName.lastIndexOf(".");
+
+        return index > -1 ? fileName.substring(index) : "";
+    }
+
+    private final File _cacheDir;
+
+    static final String LAST_ACCESSED_FILE_SUFFIX = ".lastAccessed";
+}

--- a/src/main/java/com/threerings/getdown/data/Digest.java
+++ b/src/main/java/com/threerings/getdown/data/Digest.java
@@ -5,26 +5,23 @@
 
 package com.threerings.getdown.data;
 
+import static com.threerings.getdown.Log.log;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
-
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-
 import java.util.HashMap;
 import java.util.List;
 
 import com.samskivert.io.StreamUtil;
 import com.samskivert.text.MessageUtil;
 import com.samskivert.util.StringUtil;
-
 import com.threerings.getdown.util.ConfigUtil;
 import com.threerings.getdown.util.ProgressObserver;
-
-import static com.threerings.getdown.Log.log;
 
 /**
  * Manages the <code>digest.txt</code> file and the computing and processing of MD5 digests for an
@@ -146,6 +143,14 @@ public class Digest
     protected static void note (StringBuilder data, String path, String digest)
     {
         data.append(path).append(" = ").append(digest).append("\n");
+    }
+
+    /**
+     * Returns the digest of the given {@code resource}.
+     */
+    public String getDigest (Resource resource)
+    {
+        return _digests.get(resource.getPath());
     }
 
     protected HashMap<String, String> _digests = new HashMap<String, String>();

--- a/src/main/java/com/threerings/getdown/util/FileUtil.java
+++ b/src/main/java/com/threerings/getdown/util/FileUtil.java
@@ -5,7 +5,15 @@
 
 package com.threerings.getdown.util;
 
-import java.io.*;
+import static com.threerings.getdown.Log.log;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.jar.JarOutputStream;
@@ -13,8 +21,6 @@ import java.util.jar.Pack200;
 import java.util.zip.GZIPInputStream;
 
 import com.samskivert.io.StreamUtil;
-
-import static com.threerings.getdown.Log.log;
 
 /**
  * File related utilities.
@@ -109,7 +115,6 @@ public class FileUtil extends com.samskivert.util.FileUtil
             Pack200.Unpacker unpacker = Pack200.newUnpacker();
             unpacker.unpack(packedJarIn, jarOutputStream);
             return true;
-
         } catch (IOException e) {
             log.warning("Failed to unpack packed 200 jar file", "jar", packedJar, "error", e);
             return false;
@@ -118,6 +123,24 @@ public class FileUtil extends com.samskivert.util.FileUtil
             StreamUtil.close(jarOutputStream);
             StreamUtil.close(extractedJarFileOut);
             StreamUtil.close(packedJarIn);
+        }
+    }
+
+    /**
+     * Copies the given {@code source} file to the given {@code target}.
+     */
+    public static void copy(File source, File target) throws IOException {
+        FileInputStream in = null;
+        FileOutputStream out = null;
+
+        try {
+            in = new FileInputStream(source);
+            out = new FileOutputStream(target);
+
+            StreamUtil.copy(in, out);
+        } finally {
+            StreamUtil.close(in);
+            StreamUtil.close(out);
         }
     }
 }

--- a/src/main/java/com/threerings/getdown/util/file/FileVisitor.java
+++ b/src/main/java/com/threerings/getdown/util/file/FileVisitor.java
@@ -1,0 +1,6 @@
+package com.threerings.getdown.util.file;
+import java.io.File;
+
+public interface FileVisitor {
+    void visit(File file);
+}

--- a/src/main/java/com/threerings/getdown/util/file/FileWalker.java
+++ b/src/main/java/com/threerings/getdown/util/file/FileWalker.java
@@ -1,0 +1,42 @@
+package com.threerings.getdown.util.file;
+
+import java.io.File;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Deque;
+
+/**
+ * Recursively walks over files and folders. A {@link FileVisitor visitor} is informed for each path
+ * traversed.
+ */
+public class FileWalker
+{
+    public FileWalker (File start)
+    {
+        this._start = start;
+    }
+
+    /**
+     * Walks over the directory tree with the provided {@code visitor}.
+     */
+    public void walkTree (FileVisitor visitor)
+    {
+        Deque<File> stack = new ArrayDeque<File>(Arrays.asList(_start.listFiles()));
+
+        while (!stack.isEmpty()) {
+            File currentFile = stack.pop();
+
+            if (currentFile.exists()) {
+                visitor.visit(currentFile);
+
+                if (currentFile.isDirectory()) {
+                    for (File file: currentFile.listFiles()) {
+                        stack.push(file);
+                    }
+                }
+            }
+        }
+    }
+
+    private final File _start;
+}

--- a/src/test/java/com/threerings/getdown/classpath/CacheBasedClassPathBuilderTest.java
+++ b/src/test/java/com/threerings/getdown/classpath/CacheBasedClassPathBuilderTest.java
@@ -1,0 +1,44 @@
+package com.threerings.getdown.classpath;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.threerings.getdown.util.FileUtil;
+
+/**
+ * Tests {@link CacheBasedClassPathBuilderTest}.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class CacheBasedClassPathBuilderTest extends ClassPathBuilderTestBase
+{
+    @Test
+    public void shouldBuildCacheBasedClassPath () throws IOException
+    {
+        when(_application.getDigest(_firstJar)).thenReturn("first");
+        when(_application.getDigest(_secondJar)).thenReturn("second");
+        when(_application.getCodeCacheRetentionDays()).thenReturn(1);
+
+        File firstCachedJarFile = FileUtil.newFile(
+                _appdir.getRoot(),
+                CacheBasedClassPathBuilder.CACHE_DIR, "fi", "first.jar");
+
+        File secondCachedJarFile = FileUtil.newFile(
+                _appdir.getRoot(),
+                CacheBasedClassPathBuilder.CACHE_DIR, "se", "second.jar");
+
+        String expectedClassPath = firstCachedJarFile.getAbsolutePath()
+                + File.pathSeparator
+                + secondCachedJarFile.getAbsolutePath();
+
+        ClassPath classPath = new CacheBasedClassPathBuilder(_application).buildClassPath();
+
+        assertEquals(expectedClassPath, classPath.asArgumentString());
+    }
+}

--- a/src/test/java/com/threerings/getdown/classpath/ClassPathBuilderFactoryTest.java
+++ b/src/test/java/com/threerings/getdown/classpath/ClassPathBuilderFactoryTest.java
@@ -1,0 +1,37 @@
+package com.threerings.getdown.classpath;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.threerings.getdown.data.Application;
+
+/**
+ * Checks wether the correct {@link ClassPathBuilder class path builders} are created.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ClassPathBuilderFactoryTest
+{
+    @Test
+    public void shouldCreateDefaultClassPathBuilder ()
+    {
+        when(_application.isUseCodeCache()).thenReturn(Boolean.FALSE);
+
+        assertTrue(ClassPathBuilderFactory.create(_application) instanceof DefaultClassPathBuilder);
+    }
+
+    @Test
+    public void shouldCreateCacheClassPathBuilder ()
+    {
+        when(_application.isUseCodeCache()).thenReturn(Boolean.TRUE);
+
+        assertTrue(ClassPathBuilderFactory.create(_application) instanceof CacheBasedClassPathBuilder);
+    }
+
+    @Mock
+    private Application _application;
+}

--- a/src/test/java/com/threerings/getdown/classpath/ClassPathBuilderTestBase.java
+++ b/src/test/java/com/threerings/getdown/classpath/ClassPathBuilderTestBase.java
@@ -1,0 +1,48 @@
+package com.threerings.getdown.classpath;
+
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.Mock;
+
+import com.threerings.getdown.data.Application;
+import com.threerings.getdown.data.Resource;
+
+/**
+ * Base class for {@link ClassPathBuilder} tests.
+ */
+public abstract class ClassPathBuilderTestBase {
+    @Before
+    public void setupFilesAndResources () throws IOException
+    {
+        _firstJarFile = _appdir.newFile("a.jar");
+        _secondJarFile = _appdir.newFile("b.jar");
+
+        when(_firstJar.getFinalTarget()).thenReturn(_firstJarFile);
+        when(_secondJar.getFinalTarget()).thenReturn(_secondJarFile);
+        when(_application.getActiveCodeResources()).thenReturn(Arrays.asList(_firstJar, _secondJar));
+        when(_application.getAppdir()).thenReturn(_appdir.getRoot());
+    }
+
+    @Mock
+    protected Application _application;
+
+    @Mock
+    protected Resource _firstJar;
+
+    protected File _firstJarFile;
+
+    @Mock
+    protected Resource _secondJar;
+
+    protected File _secondJarFile;
+
+    @Rule
+    public TemporaryFolder _appdir = new TemporaryFolder();
+}

--- a/src/test/java/com/threerings/getdown/classpath/ClassPathTest.java
+++ b/src/test/java/com/threerings/getdown/classpath/ClassPathTest.java
@@ -1,0 +1,60 @@
+package com.threerings.getdown.classpath;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.LinkedHashSet;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Tests for {@link ClassPath}.
+ */
+public class ClassPathTest
+{
+    @Before
+    public void createJarsAndSetupClassPath () throws IOException
+    {
+        _firstJar = _folder.newFile("a.jar");
+        _secondJar = _folder.newFile("b.jar");
+
+        LinkedHashSet<ClassPathElement> classPathEntries = new LinkedHashSet<ClassPathElement>();
+
+        classPathEntries.add(new ClassPathElement(_firstJar));
+        classPathEntries.add(new ClassPathElement(_secondJar));
+
+        _classPath = new ClassPath(classPathEntries);
+    }
+
+    @Test
+    public void shouldCreateValidArgumentString ()
+    {
+        assertEquals(
+                _firstJar.getAbsolutePath() + File.pathSeparator + _secondJar.getAbsolutePath(),
+                _classPath.asArgumentString());
+    }
+
+    @Test
+    public void shouldProvideJarUrls () throws MalformedURLException, URISyntaxException
+    {
+        URL[] actualUrls = _classPath.asUrls();
+
+        assertEquals(_firstJar, new File(actualUrls[0].toURI()));
+        assertEquals(_secondJar, new File(actualUrls[1].toURI()));
+    }
+
+    @Rule
+    public TemporaryFolder _folder = new TemporaryFolder();
+
+    private File _firstJar;
+    private File _secondJar;
+
+    private ClassPath _classPath;
+}

--- a/src/test/java/com/threerings/getdown/classpath/DefaultClassPathBuilderTest.java
+++ b/src/test/java/com/threerings/getdown/classpath/DefaultClassPathBuilderTest.java
@@ -1,0 +1,31 @@
+package com.threerings.getdown.classpath;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+/**
+ * Tests the {@link DefaultClassPathBuilder}.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class DefaultClassPathBuilderTest extends ClassPathBuilderTestBase
+{
+    @Test
+    public void shouldBuildClassPath () throws IOException
+    {
+        ClassPath classPath = new DefaultClassPathBuilder(_application).buildClassPath();
+
+        String expectedClassPath = _firstJarFile.getAbsolutePath()
+                + File.pathSeparator
+                + _secondJarFile.getAbsolutePath();
+
+        assertEquals(expectedClassPath, classPath.asArgumentString());
+    }
+
+
+}

--- a/src/test/java/com/threerings/getdown/classpath/cache/GarbageCollectorTest.java
+++ b/src/test/java/com/threerings/getdown/classpath/cache/GarbageCollectorTest.java
@@ -1,0 +1,91 @@
+package com.threerings.getdown.classpath.cache;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import com.threerings.getdown.util.file.FileWalker;
+
+/**
+ * Validates that cache garbage is collected and deleted correctly.
+ */
+public class GarbageCollectorTest
+{
+    @Before
+    public void setupFiles () throws IOException
+    {
+        _cachedFile = _folder.newFile("abc123.jar");
+        _lastAccessedFile = _folder.newFile("abc123.jar" + ResourceCache.LAST_ACCESSED_FILE_SUFFIX);
+    }
+
+    @Test
+    public void shouldDeleteCacheEntryIfRetentionPeriodIsReached ()
+    {
+        gcNow();
+
+        assertFalse(_cachedFile.exists());
+        assertFalse(_lastAccessedFile.exists());
+    }
+
+    @Test
+    public void shouldDeleteCacheFolderIfFolderIsEmpty ()
+    {
+        gcNow();
+
+        assertFalse(_folder.getRoot().exists());
+    }
+
+    private void gcNow() {
+        GarbageCollector collector = new GarbageCollector(
+                new FileWalker(_folder.getRoot()), -1, TimeUnit.MILLISECONDS);
+
+        collector.collectGarbage();
+    }
+
+    @Test
+    public void shouldKeepFilesInCacheIfRententionPeriodIsNotReached ()
+    {
+        GarbageCollector collector = new GarbageCollector(
+                new FileWalker(_folder.getRoot()), 1, TimeUnit.DAYS);
+
+        collector.collectGarbage();
+
+        assertTrue(_cachedFile.exists());
+        assertTrue(_lastAccessedFile.exists());
+    }
+
+    @Test
+    public void shouldDeleteCachedFileIfLastAccessedFileIsMissing ()
+    {
+        assumeTrue(_lastAccessedFile.delete());
+
+        gcNow();
+
+        assertFalse(_cachedFile.exists());
+    }
+
+    @Test
+    public void shouldDeleteLastAccessedFileIfCachedFileIsMissing ()
+    {
+        assumeTrue(_cachedFile.delete());
+
+        gcNow();
+
+        assertFalse(_lastAccessedFile.exists());
+    }
+
+    @Rule
+    public TemporaryFolder _folder = new TemporaryFolder();
+
+    private File _cachedFile;
+    private File _lastAccessedFile;
+}

--- a/src/test/java/com/threerings/getdown/classpath/cache/ResourceCacheTest.java
+++ b/src/test/java/com/threerings/getdown/classpath/cache/ResourceCacheTest.java
@@ -49,7 +49,7 @@ public class ResourceCacheTest
     {
         File cachedFile = cacheFile();
 
-        TimeUnit.MILLISECONDS.sleep(50);
+        TimeUnit.MILLISECONDS.sleep(500);
 
         // caching it another time
         File sameCachedFile = cacheFile();
@@ -62,7 +62,7 @@ public class ResourceCacheTest
     {
         cacheFile();
 
-        TimeUnit.MILLISECONDS.sleep(50);
+        TimeUnit.MILLISECONDS.sleep(500);
 
         // caching it another time
         File sameCachedFile = cacheFile();

--- a/src/test/java/com/threerings/getdown/classpath/cache/ResourceCacheTest.java
+++ b/src/test/java/com/threerings/getdown/classpath/cache/ResourceCacheTest.java
@@ -49,28 +49,34 @@ public class ResourceCacheTest
     {
         File cachedFile = cacheFile();
 
-        TimeUnit.MILLISECONDS.sleep(500);
+        cachedFile.setLastModified(YESTERDAY);
+
+        long expectedLastModified = cachedFile.lastModified();
 
         // caching it another time
         File sameCachedFile = cacheFile();
 
-        assertEquals(cachedFile.lastModified(), sameCachedFile.lastModified());
+        assertEquals(expectedLastModified, sameCachedFile.lastModified());
     }
 
     @Test
     public void shouldRememberWhenFileWasRequested () throws Exception
     {
-        cacheFile();
+        File cachedFile = cacheFile();
 
-        TimeUnit.MILLISECONDS.sleep(500);
+        File lastAccessedFile = new File(
+                cachedFile.getParentFile(),
+                cachedFile.getName() + ResourceCache.LAST_ACCESSED_FILE_SUFFIX);
+
+        lastAccessedFile.setLastModified(YESTERDAY);
+
+        long lastAccessed = lastAccessedFile.lastModified();
 
         // caching it another time
-        File sameCachedFile = cacheFile();
-        File lastAccessed = new File(
-                sameCachedFile.getParentFile(),
-                sameCachedFile.getName() + ResourceCache.LAST_ACCESSED_FILE_SUFFIX);
+        cacheFile();
 
-        assertTrue(lastAccessed.lastModified() > sameCachedFile.lastModified());
+
+        assertTrue(lastAccessedFile.lastModified() > lastAccessed);
     }
 
     @Rule
@@ -78,4 +84,6 @@ public class ResourceCacheTest
 
     private File _fileToCache;
     private ResourceCache _cache;
+
+    private static final long YESTERDAY = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(1);
 }

--- a/src/test/java/com/threerings/getdown/classpath/cache/ResourceCacheTest.java
+++ b/src/test/java/com/threerings/getdown/classpath/cache/ResourceCacheTest.java
@@ -1,0 +1,81 @@
+package com.threerings.getdown.classpath.cache;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Asserts the correct functionality of the {@link ResourceCache}.
+ */
+public class ResourceCacheTest
+{
+    @Before
+    public void setupCache () throws IOException {
+        _fileToCache = _folder.newFile("filetocache.jar");
+        _cache = new ResourceCache(_folder.newFolder(".cache"));
+    }
+
+    @Test
+    public void shouldCacheFile () throws IOException
+    {
+        assertEquals("abc123.jar", cacheFile().getName());
+    }
+
+    private File cacheFile() throws IOException
+    {
+        return _cache.cacheFile(_fileToCache, "abc123");
+    }
+
+    @Test
+    public void shouldTrackFileUsage () throws IOException
+    {
+        File lastAccessedFile = new File(
+                cacheFile().getParentFile(),
+                "abc123.jar" + ResourceCache.LAST_ACCESSED_FILE_SUFFIX);
+
+        assertTrue(lastAccessedFile.exists());
+    }
+
+    @Test
+    public void shouldNotCacheTheSameFile () throws Exception
+    {
+        File cachedFile = cacheFile();
+
+        TimeUnit.MILLISECONDS.sleep(5);
+
+        // caching it another time
+        File sameCachedFile = cacheFile();
+
+        assertEquals(cachedFile.lastModified(), sameCachedFile.lastModified());
+    }
+
+    @Test
+    public void shouldRememberWhenFileWasRequested () throws Exception
+    {
+        cacheFile();
+
+        TimeUnit.MILLISECONDS.sleep(5);
+
+        // caching it another time
+        File sameCachedFile = cacheFile();
+        File lastAccessed = new File(
+                sameCachedFile.getParentFile(),
+                sameCachedFile.getName() + ResourceCache.LAST_ACCESSED_FILE_SUFFIX);
+
+        assertTrue(lastAccessed.lastModified() > sameCachedFile.lastModified());
+    }
+
+    @Rule
+    public TemporaryFolder _folder = new TemporaryFolder();
+
+    private File _fileToCache;
+    private ResourceCache _cache;
+}

--- a/src/test/java/com/threerings/getdown/classpath/cache/ResourceCacheTest.java
+++ b/src/test/java/com/threerings/getdown/classpath/cache/ResourceCacheTest.java
@@ -49,7 +49,7 @@ public class ResourceCacheTest
     {
         File cachedFile = cacheFile();
 
-        TimeUnit.MILLISECONDS.sleep(5);
+        TimeUnit.MILLISECONDS.sleep(50);
 
         // caching it another time
         File sameCachedFile = cacheFile();
@@ -62,7 +62,7 @@ public class ResourceCacheTest
     {
         cacheFile();
 
-        TimeUnit.MILLISECONDS.sleep(5);
+        TimeUnit.MILLISECONDS.sleep(50);
 
         // caching it another time
         File sameCachedFile = cacheFile();

--- a/src/test/java/com/threerings/getdown/util/FileUtilTest.java
+++ b/src/test/java/com/threerings/getdown/util/FileUtilTest.java
@@ -5,26 +5,49 @@
 
 package com.threerings.getdown.util;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
 import java.util.List;
 
-import org.junit.*;
-import static org.junit.Assert.*;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 /**
  * Tests {@link FileUtil}.
  */
 public class FileUtilTest
 {
-    @Test public void testReadLines () throws IOException
+    @Test
+    public void testReadLines () throws IOException
     {
         String data = "This is a test\nof a file with\na few lines\n";
         List<String> lines = FileUtil.readLines(new StringReader(data));
         String[] linesBySplit = data.split("\n");
         assertEquals(linesBySplit.length, lines.size());
-        for (int ii = 0; ii < lines.size(); ii++) {
-            assertEquals(linesBySplit[ii], lines.get(ii));
+        for (int i = 0; i < lines.size(); i++) {
+            assertEquals(linesBySplit[i], lines.get(i));
         }
     }
+
+    @Test
+    public void shouldCopyFile () throws IOException
+    {
+        File source = _folder.newFile("source.txt");
+        File target = new File(_folder.getRoot(), "target.txt");
+
+        assertFalse(target.exists());
+
+        FileUtil.copy(source, target);
+
+        assertTrue(target.exists());
+    }
+
+    @Rule
+    public TemporaryFolder _folder = new TemporaryFolder();
 }

--- a/src/test/java/com/threerings/getdown/util/file/FileWalkerTest.java
+++ b/src/test/java/com/threerings/getdown/util/file/FileWalkerTest.java
@@ -1,0 +1,41 @@
+package com.threerings.getdown.util.file;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Class under test: {@link FileWalker}.
+ */
+public class FileWalkerTest
+{
+    @Test
+    public void shouldRecursivelyWalkOverFilesAndFolders () throws IOException
+    {
+        _folder.newFile("a.txt");
+        new File(_folder.newFolder("b"), "b.txt").createNewFile();
+
+        CountingVisitor visitor = new CountingVisitor();
+        new FileWalker(_folder.getRoot()).walkTree(visitor);
+
+        assertEquals(3, visitor.fileCount);
+    }
+
+    public static class CountingVisitor implements FileVisitor
+    {
+        int fileCount = 0;
+
+        @Override
+        public void visit(File file) {
+            fileCount++;
+        }
+    }
+
+    @Rule
+    public TemporaryFolder _folder = new TemporaryFolder();
+}


### PR DESCRIPTION
This PR is basically what has been agreed in issue #64.

Whenever

    use_code_cache = true

is configured in `getdown.txt`, all code resources are copied over to a cache directory (`.cache`) prior to launching the application. The class path of the application then only contains elements from the cache directory. This basically enables multiple application instances of (slightly) different versions to be opened at the same time.

The cache is regularly tidied up by tracking the usage of the jar files. If the files have not been used since a configurable amount of days they get deleted. The configuration property is

    code_cache_retention_days = $days

If not given, the default of "one week" is used.

The cache is considered to be transient. It can be deleted any time (as long as no application is running) and will be populated again upon application start.