### PR TITLE
GetdownApp launcher: use local X.509 certificate from digest.txt.crt if available

### DIFF
--- a/src/main/java/com/threerings/getdown/data/Application.java
+++ b/src/main/java/com/threerings/getdown/data/Application.java
@@ -1507,7 +1507,7 @@ public class Application
                     FileInputStream dataInput = null;
                     try {
                         dataInput = new FileInputStream(target);
-                        Signature sig = Signature.getInstance("SHA1withRSA");
+                        Signature sig = Signature.getInstance("SHA256withRSA");
                         sig.initVerify(cert);
                         while ((length = dataInput.read(buffer)) != -1) {
                             sig.update(buffer, 0, length);

--- a/src/main/java/com/threerings/getdown/data/Digest.java
+++ b/src/main/java/com/threerings/getdown/data/Digest.java
@@ -142,9 +142,9 @@ public class Digest
     public static MessageDigest getMessageDigest ()
     {
         try {
-            return MessageDigest.getInstance("MD5");
+            return MessageDigest.getInstance("SHA-256");
         } catch (NoSuchAlgorithmException nsae) {
-            throw new RuntimeException("JVM does not support MD5. Gurp!");
+            throw new RuntimeException("JVM does not support SHA-256. Gurp!");
         }
     }
 


### PR DESCRIPTION
If client has **digest.txt.crt** beside **getdown.txt** then use it( it's public key) to verify remote **digest.txt**.
Simple way to provide secure provisioning.
Certificate update uncovered.
