### PR TITLE
bugfix for ProgressAggregator

### DIFF
--- a/src/main/java/com/threerings/getdown/util/ConfigUtil.java
+++ b/src/main/java/com/threerings/getdown/util/ConfigUtil.java
@@ -142,8 +142,8 @@ public class ConfigUtil
                 // if we're checking qualifiers and the os doesn't match this qualifier, skip it
                 String quals = pair[1].substring(1, qidx);
                 if (osname != null && !checkQualifiers(quals, osname, osarch)) {
-                    log.info("Skipping", "quals", quals, "osname", osname, "osarch", osarch,
-                             "key", pair[0], "value", pair[1]);
+                    log.debug("Skipping", "quals", quals, "osname", osname, "osarch", osarch,
+                              "key", pair[0], "value", pair[1]);
                     continue;
                 }
                 // otherwise filter out the qualifier text

--- a/src/main/java/com/threerings/getdown/util/ProgressAggregator.java
+++ b/src/main/java/com/threerings/getdown/util/ProgressAggregator.java
@@ -20,7 +20,7 @@ public class ProgressAggregator
     public ProgressObserver startElement (final int index) {
         return new ProgressObserver() {
             public void progress (int percent) {
-                _sizes[index] = percent;
+                _progress[index] = percent;
                 updateAggProgress();
             }
         };


### PR DESCRIPTION
There seemed to be an issue in the progress method of generated ProgressObserver which updated _sizes array instead of _progress array. The global effect is that the progressbar now behave more fluidly when verifying, unpacking and patching.