### PR TITLE
bugfix when getdown stopped after downloading before installing

### DIFF
--- a/src/main/java/com/threerings/getdown/data/Application.java
+++ b/src/main/java/com/threerings/getdown/data/Application.java
@@ -1276,7 +1276,7 @@ public class Application
      * @param unpacked a set to populate with unpacked resources.
      */
     public List<Resource> verifyResources (ProgressObserver obs, int[] alreadyValid,
-                                           Set<Resource> unpacked) throws InterruptedException
+                                           Set<Resource> unpacked, List<Resource> toBeInstalled) throws InterruptedException
     {
         List<Resource> rsrcs = getAllActiveResources();
         List<Resource> failures = new ArrayList<Resource>();
@@ -1306,6 +1306,10 @@ public class Application
 
             try {
                 if (_digest.validateResource(rsrc, robs)) {
+                    //if the resource is valid but has no _local file, we add it to the resource to install
+                    if (!rsrc.getLocal().exists() && rsrc.getLocalNew().exists() && !toBeInstalled.contains(rsrc)) {
+                        toBeInstalled.add(rsrc);
+                    }
                     // unpack this resource if appropriate
                     if (noUnpack || !rsrc.shouldUnpack()) {
                         // finally note that this resource is kosher

--- a/src/main/java/com/threerings/getdown/launcher/Getdown.java
+++ b/src/main/java/com/threerings/getdown/launcher/Getdown.java
@@ -476,7 +476,7 @@ public abstract class Getdown extends Thread
                 // now verify our resources...
                 setStep(Step.VERIFY_RESOURCES);
                 setStatusAsync("m.validating", -1, -1L, false);
-                List<Resource> failures = _app.verifyResources(_progobs, alreadyValid, unpacked);
+                List<Resource> failures = _app.verifyResources(_progobs, alreadyValid, unpacked, _toBeInstalledResouces);
                 if (failures == null) {
                     log.info("Resources verified.");
 


### PR DESCRIPTION
If the app was stopped in the middle of dl, next time it is launched, some resources can have localNew but no local file, they will be valid but not in the list to install, therefore there will never be installation on these resources. 

My suggested correction is to check if we have localNew but not local for a valid resource and put it in the _toBeInstalledResources list.