### PR TITLE
allow transparent splash screens 

### DIFF
--- a/src/main/java/com/threerings/getdown/data/Application.java
+++ b/src/main/java/com/threerings/getdown/data/Application.java
@@ -1749,7 +1749,9 @@ public class Application
     {
         if (!StringUtil.isBlank(hexValue)) {
             try {
-                return new Color(Integer.parseInt(hexValue, 16));
+                int rgba = Integer.parseInt(hexValue, 16);
+                boolean hasAlpha = hexValue.length() > 6;
+                return new Color(rgba, hasAlpha);
             } catch (NumberFormatException e) {
                 log.warning("Ignoring invalid color", "hexValue", hexValue, "exception", e);
             }

--- a/src/main/java/com/threerings/getdown/launcher/GetdownApp.java
+++ b/src/main/java/com/threerings/getdown/launcher/GetdownApp.java
@@ -5,6 +5,7 @@
 
 package com.threerings.getdown.launcher;
 
+import java.awt.EventQueue;
 import java.awt.Color;
 import java.awt.Container;
 import java.awt.IllegalComponentStateException;
@@ -22,7 +23,6 @@ import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import javax.swing.JFrame;
@@ -231,20 +231,25 @@ public class GetdownApp
 
             @Override
             protected void fail (String message) {
-                // if the frame was set to be undecorated, make window decoration available
-                // to allow the user to close the window
-                if (_frame != null && _frame.isUndecorated()) {
-                    _frame.dispose();
-                    Color background = _frame.getBackground();
-                    if (background != null && background.getAlpha() < 255) {
-                        // decorated windows do not allow alpha backgrounds
-                        _frame.setBackground(
-                            new Color(background.getRed(), background.getGreen(), background.getBlue()));
-                    }
-                    _frame.setUndecorated(false);
-                    showContainer();
-                }
                 super.fail(message);
+                EventQueue.invokeLater(new Runnable() {
+                    @Override
+                    public void run() {
+                        // if the frame was set to be undecorated, make window decoration available
+                        // to allow the user to close the window
+                        if (_frame != null && _frame.isUndecorated()) {
+                            _frame.dispose();
+                            Color background = _frame.getBackground();
+                            if (background != null && background.getAlpha() < 255) {
+                                // decorated windows do not allow alpha backgrounds
+                                _frame.setBackground(
+                                    new Color(background.getRed(), background.getGreen(), background.getBlue()));
+                            }
+                            _frame.setUndecorated(false);
+                            showContainer();
+                        }
+                    }
+                });
             }
 
             protected JFrame _frame;

--- a/src/main/java/com/threerings/getdown/launcher/GetdownApp.java
+++ b/src/main/java/com/threerings/getdown/launcher/GetdownApp.java
@@ -5,7 +5,9 @@
 
 package com.threerings.getdown.launcher;
 
+import java.awt.Color;
 import java.awt.Container;
+import java.awt.IllegalComponentStateException;
 import java.awt.Image;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
@@ -141,6 +143,13 @@ public class GetdownApp
                         }
                     });
                     _frame.setUndecorated(_ifc.hideDecorations);
+                    try {
+                        _frame.setBackground(_ifc.background);
+                    } catch (UnsupportedOperationException e) {
+                        log.warning("Failed to set background", e);
+                    } catch (IllegalComponentStateException e) {
+                        log.warning("Failed to set background", e);
+                    }
                     _frame.setResizable(false);
                 } else {
                     _frame.setTitle(title);
@@ -226,6 +235,12 @@ public class GetdownApp
                 // to allow the user to close the window
                 if (_frame != null && _frame.isUndecorated()) {
                     _frame.dispose();
+                    Color background = _frame.getBackground();
+                    if (background != null && background.getAlpha() < 255) {
+                        // decorated windows do not allow alpha backgrounds
+                        _frame.setBackground(
+                            new Color(background.getRed(), background.getGreen(), background.getBlue()));
+                    }
                     _frame.setUndecorated(false);
                     showContainer();
                 }

--- a/src/main/java/com/threerings/getdown/launcher/GetdownApplet.java
+++ b/src/main/java/com/threerings/getdown/launcher/GetdownApplet.java
@@ -104,6 +104,7 @@ public class GetdownApplet extends JApplet
                 @Override
                 protected Container createContainer () {
                     getContentPane().removeAll();
+                    getContentPane().setBackground(_ifc.background);
                     return getContentPane();
                 }
                 @Override

--- a/src/main/java/com/threerings/getdown/launcher/StatusPanel.java
+++ b/src/main/java/com/threerings/getdown/launcher/StatusPanel.java
@@ -189,10 +189,7 @@ public class StatusPanel extends JComponent
         super.paintComponent(g);
         Graphics2D gfx = (Graphics2D)g;
 
-        // always draw a background in case our image isn't ready yet
-        gfx.setColor(_ifc.background);
-        gfx.fillRect(0, 0, getWidth(), getHeight());
-        // then attempt to draw a background image...
+        // attempt to draw a background image...
         Image img;
         if (_displayError) {
             img = _bg.getErrorImage();


### PR DESCRIPTION
When defining a background color, it is now possible to define an alpha
value as most significant byte. E.g. `80FF0000` would define a half
transparent red background. This only works in combination with
`ui.hide_decorations = true`.