### PR TITLE
change default Java version regex

### DIFF
--- a/src/main/java/com/threerings/getdown/data/Application.java
+++ b/src/main/java/com/threerings/getdown/data/Application.java
@@ -1882,7 +1882,7 @@ public class Application
     protected int _trackingId;
 
     protected String _javaVersionProp = "java.version";
-    protected String _javaVersionRegex = "(\\d+)\\.(\\d+)\\.(\\d+)(_\\d+)?.*";
+    protected String _javaVersionRegex = "(\\d+)(?:\\.(\\d+)(?:\\.(\\d+)(_\\d+)?)?)?";
     protected long _javaMinVersion, _javaMaxVersion;
     protected boolean _javaExactVersionRequired;
     protected String _javaLocation;

--- a/src/test/java/com/threerings/getdown/util/VersionUtilTest.java
+++ b/src/test/java/com/threerings/getdown/util/VersionUtilTest.java
@@ -7,7 +7,7 @@ package com.threerings.getdown.util;
 
 import org.junit.Test;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 
 public class VersionUtilTest {
 
@@ -15,8 +15,32 @@ public class VersionUtilTest {
     public void shouldParseJavaVersion ()
     {
         long version = VersionUtil.parseJavaVersion(
-            "(\\d+)\\.(\\d+)\\.(\\d+)(_\\d+)?", "1.8.0_152");
-        assertTrue(version > 1060000);
+            "(\\d+)(?:\\.(\\d+)(?:\\.(\\d+)(_\\d+)?)?)?", "1.8.0_152");
+        assertEquals(1_080_152, version);
+    }
+
+    @Test
+    public void shouldParseJavaVersion8 ()
+    {
+        long version = VersionUtil.parseJavaVersion(
+            "(\\d+)(?:\\.(\\d+)(?:\\.(\\d+)(_\\d+)?)?)?", "1.8");
+        assertEquals(1_080_000, version);
+    }
+
+    @Test
+    public void shouldParseJavaVersion9 ()
+    {
+        long version = VersionUtil.parseJavaVersion(
+            "(\\d+)(?:\\.(\\d+)(?:\\.(\\d+)(_\\d+)?)?)?", "9");
+        assertEquals(9_000_000, version);
+    }
+
+    @Test
+    public void shouldParseJavaVersion10 ()
+    {
+        long version = VersionUtil.parseJavaVersion(
+            "(\\d+)(?:\\.(\\d+)(?:\\.(\\d+)(_\\d+)?)?)?", "10");
+        assertEquals(10_000_000, version);
     }
 
     @Test
@@ -24,6 +48,6 @@ public class VersionUtilTest {
     {
         long version = VersionUtil.parseJavaVersion(
             "(\\d+)\\.(\\d+)\\.(\\d+)(_\\d+)?(-b\\d+)?", "1.8.0_131-b11");
-        assertTrue(version > 106000000);
+        assertEquals(108_013_111, version);
     }
 }


### PR DESCRIPTION
Java Versions >= 9 do not work with the default regex

The default Java Version Regex is (\d+)\.(\d+)\.(\d+)(_\d+)?.*, but e.g. the first Java 9 version had 9 as Version String, and the first Java 10 version had 10 as Version String. Only the second Java 9 Version had 9.0.1 as String. This results in the version not beaing checked.

Although it is possible to set the java_version_regex in the getdown.txt file, the default should be changed to (\d+)(?:\.(\d+)(?:\.(\d+)(_\d+)?)?)?, making only the major number mandatory.