### PR TITLE
Reliance on default encoding

### DIFF
--- a/src/main/java/com/threerings/getdown/data/Application.java
+++ b/src/main/java/com/threerings/getdown/data/Application.java
@@ -42,6 +42,7 @@ import com.threerings.getdown.util.*;
 import com.threerings.getdown.util.Base64;
 
 import static com.threerings.getdown.Log.log;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Parses and provide access to the information contained in the <code>getdown.txt</code>
@@ -1242,7 +1243,7 @@ public class Application
 
             if (_latest != null) {
                 try (InputStream in = ConnectionUtil.open(_latest, 0, 0).getInputStream();
-                     InputStreamReader reader = new InputStreamReader(in);
+                     InputStreamReader reader = new InputStreamReader(in, UTF_8);
                      BufferedReader bin = new BufferedReader(reader)) {
                     for (String[] pair : Config.parsePairs(bin, Config.createOpts(false))) {
                         if (pair[0].equals("version")) {

--- a/src/main/java/com/threerings/getdown/data/Application.java
+++ b/src/main/java/com/threerings/getdown/data/Application.java
@@ -1564,8 +1564,8 @@ public class Application
             } else {
                 File signatureFile = downloadFile(path + SIGNATURE_SUFFIX);
                 byte[] signature = null;
-                try (FileReader reader = new FileReader(signatureFile)) {
-                    signature = StreamUtil.toByteArray(new FileInputStream(signatureFile));
+                try (FileInputStream signatureStream = new FileInputStream(signatureFile)) {
+                    signature = StreamUtil.toByteArray(signatureStream);
                 } finally {
                     FileUtil.deleteHarder(signatureFile); // delete the file regardless
                 }

--- a/src/main/java/com/threerings/getdown/data/Digest.java
+++ b/src/main/java/com/threerings/getdown/data/Digest.java
@@ -19,6 +19,7 @@ import com.threerings.getdown.util.Config;
 import com.threerings.getdown.util.ProgressObserver;
 
 import static com.threerings.getdown.Log.log;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Manages the <code>digest.txt</code> file and the computing and processing of digests for an
@@ -111,7 +112,7 @@ public class Digest
             }
             // finally compute and append the digest for the file contents
             MessageDigest md = getMessageDigest(version);
-            byte[] contents = data.toString().getBytes("UTF-8");
+            byte[] contents = data.toString().getBytes(UTF_8);
             String filename = digestFile(version);
             pout.println(filename + " = " + StringUtil.hexlate(md.digest(contents)));
         }
@@ -168,7 +169,7 @@ public class Digest
 
         // we've reached the end, validate our contents
         MessageDigest md = getMessageDigest(version);
-        byte[] contents = data.toString().getBytes("UTF-8");
+        byte[] contents = data.toString().getBytes(UTF_8);
         String hash = StringUtil.hexlate(md.digest(contents));
         if (!hash.equals(_metaDigest)) {
             String err = MessageUtil.tcompose("m.invalid_digest_file", _metaDigest, hash);

--- a/src/main/java/com/threerings/getdown/tools/AppletParamSigner.java
+++ b/src/main/java/com/threerings/getdown/tools/AppletParamSigner.java
@@ -14,6 +14,8 @@ import java.security.Signature;
 import com.threerings.getdown.data.Digest;
 import com.threerings.getdown.util.Base64;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 /**
  * Produces a signed hash of the appbase, appname, and image path to ensure that signed copies of
  * Getdown are not hijacked to run malicious code.
@@ -45,7 +47,7 @@ public class AppletParamSigner
             PrivateKey key = (PrivateKey)store.getKey(alias, keypass.toCharArray());
             Signature sig = Signature.getInstance(Digest.sigAlgorithm(Digest.VERSION));
             sig.initSign(key);
-            sig.update(params.getBytes());
+            sig.update(params.getBytes(UTF_8));
             String signed = Base64.encodeToString(sig.sign(), Base64.DEFAULT);
             System.out.println("<param name=\"appbase\" value=\"" + appbase + "\" />");
             System.out.println("<param name=\"appname\" value=\"" + appname + "\" />");

--- a/src/main/java/com/threerings/getdown/tools/Digester.java
+++ b/src/main/java/com/threerings/getdown/tools/Digester.java
@@ -23,6 +23,8 @@ import com.threerings.getdown.data.Digest;
 import com.threerings.getdown.data.Resource;
 import com.threerings.getdown.util.Base64;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 /**
  * Handles the generation of the digest.txt file.
  */
@@ -120,7 +122,7 @@ public class Digester
 
             // Write out the signature
             String signed = Base64.encodeToString(sig.sign(), Base64.DEFAULT);
-            signatureOutput.write(signed.getBytes("utf8"));
+            signatureOutput.write(signed.getBytes(UTF_8));
         }
     }
 }

--- a/src/main/java/com/threerings/getdown/tools/JarDiff.java
+++ b/src/main/java/com/threerings/getdown/tools/JarDiff.java
@@ -45,6 +45,8 @@ import java.io.*;
 import java.util.*;
 import java.util.jar.*;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 /**
  * JarDiff is able to create a jar file containing the delta between two jar files (old and new).
  * The delta jar file can then be applied to the old jar file to reconstruct the new jar file.
@@ -229,7 +231,7 @@ public class JarDiff implements JarDiffCodes
         }
 
         jos.putNextEntry(new JarEntry(INDEX_NAME));
-        byte[] bytes = writer.toString().getBytes("UTF-8");
+        byte[] bytes = writer.toString().getBytes(UTF_8);
         jos.write(bytes, 0, bytes.length);
     }
 

--- a/src/main/java/com/threerings/getdown/tools/JarDiffPatcher.java
+++ b/src/main/java/com/threerings/getdown/tools/JarDiffPatcher.java
@@ -27,6 +27,8 @@ import java.util.jar.JarOutputStream;
 
 import com.threerings.getdown.util.ProgressObserver;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 /**
  * Applies a jardiff patch to a jar file.
  */
@@ -178,7 +180,7 @@ public class JarDiffPatcher implements JarDiffCodes
         }
 
         LineNumberReader indexReader =
-            new LineNumberReader(new InputStreamReader(is, "UTF-8"));
+            new LineNumberReader(new InputStreamReader(is, UTF_8));
         String line = indexReader.readLine();
         if (line == null || !line.equals(VERSION_HEADER)) {
             throw new IOException("jardiff.error.badheader: " + line);

--- a/src/main/java/com/threerings/getdown/util/Base64.java
+++ b/src/main/java/com/threerings/getdown/util/Base64.java
@@ -107,7 +107,7 @@ public class Base64 {
      * if any are present, there must be the correct number of them.
      *
      * @param str    the input String to decode, which is converted to
-     *               bytes using the default charset
+     *               bytes using ASCII
      * @param flags  controls certain features of the decoded output.
      *               Pass {@code DEFAULT} to decode standard Base64.
      *
@@ -115,7 +115,7 @@ public class Base64 {
      * incorrect padding
      */
     public static byte[] decode(String str, int flags) {
-        return decode(str.getBytes(), flags);
+        return decode(str.getBytes(US_ASCII), flags);
     }
 
     /**

--- a/src/main/java/com/threerings/getdown/util/Base64.java
+++ b/src/main/java/com/threerings/getdown/util/Base64.java
@@ -16,7 +16,7 @@
 
 package com.threerings.getdown.util;
 
-import java.io.UnsupportedEncodingException;
+import static java.nio.charset.StandardCharsets.US_ASCII;
 
 /**
  * Utilities for encoding and decoding the Base64 representation of
@@ -452,12 +452,7 @@ public class Base64 {
      *               adheres to RFC 2045.
      */
     public static String encodeToString(byte[] input, int flags) {
-        try {
-            return new String(encode(input, flags), "US-ASCII");
-        } catch (UnsupportedEncodingException e) {
-            // US-ASCII is guaranteed to be available.
-            throw new AssertionError(e);
-        }
+        return new String(encode(input, flags), US_ASCII);
     }
 
     /**
@@ -473,12 +468,7 @@ public class Base64 {
      *               adheres to RFC 2045.
      */
     public static String encodeToString(byte[] input, int offset, int len, int flags) {
-        try {
-            return new String(encode(input, offset, len, flags), "US-ASCII");
-        } catch (UnsupportedEncodingException e) {
-            // US-ASCII is guaranteed to be available.
-            throw new AssertionError(e);
-        }
+        return new String(encode(input, offset, len, flags), US_ASCII);
     }
 
     /**

--- a/src/main/java/com/threerings/getdown/util/ConnectionUtil.java
+++ b/src/main/java/com/threerings/getdown/util/ConnectionUtil.java
@@ -10,9 +10,10 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLDecoder;
-
 import com.threerings.getdown.data.SysProps;
 import com.threerings.getdown.util.Base64;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class ConnectionUtil
 {
@@ -49,7 +50,7 @@ public class ConnectionUtil
             // Remove any percent-encoding in the username/password
             userInfo = URLDecoder.decode(userInfo, "UTF-8");
             // Now base64 encode the auth info and make it a single line
-            String encoded = Base64.encodeToString(userInfo.getBytes("UTF-8"), Base64.DEFAULT).
+            String encoded = Base64.encodeToString(userInfo.getBytes(UTF_8), Base64.DEFAULT).
                 replaceAll("\\n","").replaceAll("\\r", "");
             conn.setRequestProperty("Authorization", "Basic " + encoded);
         }

--- a/src/main/java/com/threerings/getdown/util/VersionUtil.java
+++ b/src/main/java/com/threerings/getdown/util/VersionUtil.java
@@ -9,7 +9,6 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintStream;
@@ -20,6 +19,7 @@ import com.samskivert.util.StringUtil;
 
 import com.threerings.getdown.data.SysProps;
 import static com.threerings.getdown.Log.log;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Version related utilities.
@@ -33,7 +33,7 @@ public class VersionUtil
     {
         long fileVersion = -1;
         try (BufferedReader bin =
-             new BufferedReader(new InputStreamReader(new FileInputStream(vfile)))) {
+             new BufferedReader(new InputStreamReader(new FileInputStream(vfile), UTF_8))) {
             String vstr = bin.readLine();
             if (!StringUtil.isBlank(vstr)) {
                 fileVersion = Long.parseLong(vstr);
@@ -81,7 +81,8 @@ public class VersionUtil
      */
     public static long readReleaseVersion (File relfile, String versRegex)
     {
-        try (BufferedReader in = new BufferedReader(new FileReader(relfile))) {
+        try (BufferedReader in =
+             new BufferedReader(new InputStreamReader(new FileInputStream(relfile), UTF_8))) {
             String line = null, relvers = null;
             while ((line = in.readLine()) != null) {
                 if (line.startsWith("JAVA_VERSION=")) {


### PR DESCRIPTION
A few fixes and simplifications around string encoding.

(Triggered by internal security audit and Fortify analysis.)