### PR TITLE
Add missing checks against null

### DIFF
--- a/src/main/java/com/threerings/getdown/classpath/cache/GarbageCollector.java
+++ b/src/main/java/com/threerings/getdown/classpath/cache/GarbageCollector.java
@@ -30,8 +30,11 @@ public class GarbageCollector
                 }
 
                 File folder = file.getParentFile();
-                if (folder.list().length == 0) {
-                    FileUtil.deleteHarder(folder);
+                if (folder != null) {
+                    String[] children = folder.list();
+                    if (children != null && children.length == 0) {
+                        FileUtil.deleteHarder(folder);
+                    }
                 }
             }
         });

--- a/src/main/java/com/threerings/getdown/launcher/GetdownApp.java
+++ b/src/main/java/com/threerings/getdown/launcher/GetdownApp.java
@@ -197,7 +197,7 @@ public class GetdownApp
                 String[] cmdarray;
                 if (RunAnywhere.isWindows()) {
                     String osName = System.getProperty("os.name");
-                    if (osName.indexOf("9") != -1 || osName.indexOf("Me") != -1) {
+                    if (osName != null && (osName.indexOf("9") != -1 || osName.indexOf("Me") != -1)) {
                         cmdarray = new String[] {
                             "command.com", "/c", "start", "\"" + url + "\"" };
                     } else {

--- a/src/main/java/com/threerings/getdown/launcher/GetdownApplet.java
+++ b/src/main/java/com/threerings/getdown/launcher/GetdownApplet.java
@@ -93,9 +93,12 @@ public class GetdownApplet extends JApplet
                 // getSigners() returns all certificates used to sign this applet which may allow a
                 // third party to insert a trusted certificate. This should be avoided.
                 log.warning("No resource certificate found, falling back to class signers");
-                for (Object signer : GetdownApplet.class.getSigners()) {
-                    if (signer instanceof Certificate) {
-                        signers.add((Certificate)signer);
+                Object[] candidates = GetdownApplet.class.getSigners();
+                if (candidates != null) {
+                    for (Object signer : candidates) {
+                        if (signer instanceof Certificate) {
+                            signers.add((Certificate)signer);
+                        }
                     }
                 }
             }
@@ -307,7 +310,11 @@ public class GetdownApplet extends JApplet
     protected static Certificate loadCertificate (String path)
     {
         try {
-            URL keyUrl = GetdownApplet.class.getClassLoader().getResource(path);
+            ClassLoader classLoader = GetdownApplet.class.getClassLoader();
+            if (classLoader == null) {
+                return null;
+            }
+            URL keyUrl = classLoader.getResource(path);
             if (keyUrl == null) {
                 return null;
             }

--- a/src/main/java/com/threerings/getdown/tools/JarDiff.java
+++ b/src/main/java/com/threerings/getdown/tools/JarDiff.java
@@ -233,7 +233,7 @@ public class JarDiff implements JarDiffCodes
         jos.write(bytes, 0, bytes.length);
     }
 
-    private static void writeEscapedString (Writer writer, String string)
+    protected static Writer writeEscapedString (Writer writer, String string)
         throws IOException
     {
         int index = 0;
@@ -251,13 +251,15 @@ public class JarDiff implements JarDiffCodes
             index++;
             writer.write('\\');
         }
-        if (last != 0) {
+        if (last != 0 && chars != null) {
             writer.write(chars, last, chars.length - last);
         }
         else {
             // no spaces
             writer.write(string);
         }
+
+        return writer;
     }
 
     private static void writeEntry (JarOutputStream jos, JarEntry entry, JarFile2 file)

--- a/src/main/java/com/threerings/getdown/tools/JarDiffPatcher.java
+++ b/src/main/java/com/threerings/getdown/tools/JarDiffPatcher.java
@@ -152,6 +152,10 @@ public class JarDiffPatcher implements JarDiffCodes
                 while (iEntries.hasNext()) {
                     String name = iEntries.next();
                     JarEntry entry = oldJar.getJarEntry(name);
+                    if (entry == null) {
+                        // names originally retrieved from the JAR, so this should never happen
+                        throw new AssertionError("JAR entry not found: " + name);
+                    }
                     updateObserver(observer, currentEntry, size);
                     currentEntry++;
                     writeEntry(jos, entry, oldJar);

--- a/src/main/java/com/threerings/getdown/util/FileUtil.java
+++ b/src/main/java/com/threerings/getdown/util/FileUtil.java
@@ -187,14 +187,20 @@ public class FileUtil
      */
     public static void walkTree (File root, Visitor visitor)
     {
-        Deque<File> stack = new ArrayDeque<>(Arrays.asList(root.listFiles()));
-        while (!stack.isEmpty()) {
-            File currentFile = stack.pop();
-            if (currentFile.exists()) {
-                visitor.visit(currentFile);
-                if (currentFile.isDirectory()) {
-                    for (File file: currentFile.listFiles()) {
-                        stack.push(file);
+        File[] children = root.listFiles();
+        if (children != null) {
+            Deque<File> stack = new ArrayDeque<>(Arrays.asList(children));
+            while (!stack.isEmpty()) {
+                File currentFile = stack.pop();
+                if (currentFile.exists()) {
+                    visitor.visit(currentFile);
+                    if (currentFile.isDirectory()) {
+                        File[] currentChildren = currentFile.listFiles();
+                        if (currentChildren != null) {
+                            for (File file : currentChildren) {
+                                stack.push(file);
+                            }
+                        }
                     }
                 }
             }

--- a/src/main/java/com/threerings/getdown/util/LaunchUtil.java
+++ b/src/main/java/com/threerings/getdown/util/LaunchUtil.java
@@ -182,8 +182,13 @@ public class LaunchUtil
      */
     public static boolean mustMonitorChildren ()
     {
-        String osname = System.getProperty("os.name").toLowerCase();
-        return (osname.indexOf("windows 98") != -1 || osname.indexOf("windows me") != -1);
+        String osname = System.getProperty("os.name");
+        if (osname != null) {
+            osname = osname.toLowerCase();
+            return (osname.indexOf("windows 98") != -1 || osname.indexOf("windows me") != -1);
+        } else {
+            return false;
+        }
     }
 
     /**

--- a/src/test/java/com/threerings/getdown/tools/JarDiffTest.java
+++ b/src/test/java/com/threerings/getdown/tools/JarDiffTest.java
@@ -1,0 +1,32 @@
+//
+// Getdown - application installer, patcher and launcher
+// Copyright (C) 2004-2016 Getdown authors
+// https://github.com/threerings/getdown/blob/master/LICENSE
+
+package com.threerings.getdown.tools;
+
+import java.io.IOException;
+import java.io.StringWriter;
+
+import org.junit.Test;
+
+import static com.threerings.getdown.tools.JarDiff.writeEscapedString;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests {@link JarDiff}.
+ */
+public class JarDiffTest {
+
+    @Test
+    public void testWriteEscapedString () throws IOException
+    {
+        assertEquals("abc", writeEscapedString(new StringWriter(), "abc").toString());
+        assertEquals("abc\\ xyz", writeEscapedString(new StringWriter(), "abc xyz").toString());
+        assertEquals("\\ xyz", writeEscapedString(new StringWriter(), " xyz").toString());
+        assertEquals("abc\\ ", writeEscapedString(new StringWriter(), "abc ").toString());
+        assertEquals("\\ ", writeEscapedString(new StringWriter(), " ").toString());
+        assertEquals("", writeEscapedString(new StringWriter(), "").toString());
+    }
+
+}


### PR DESCRIPTION
The program can dereference a null pointer because it does not check the return value of a function that might return.

(Triggered by internal security audit and Fortify analysis.)