### PR TITLE
Missing environment variable handled incorrectly

### DIFF
--- a/src/main/java/com/threerings/getdown/data/Application.java
+++ b/src/main/java/com/threerings/getdown/data/Application.java
@@ -1141,8 +1141,11 @@ public class Application
             StringBuffer sb = new StringBuffer();
             Matcher matcher = ENV_VAR_PATTERN.matcher(arg);
             while (matcher.find()) {
-                String varName = matcher.group(1), varValue = System.getenv(varName);
-                if (varName == null) varName = "MISSING:" + varName;
+                String varName = matcher.group(1);
+                String varValue = System.getenv(varName);
+                if (varValue == null) {
+                    varValue = "MISSING:" + varName;
+                }
                 matcher.appendReplacement(sb, varValue);
             }
             matcher.appendTail(sb);


### PR DESCRIPTION
It looks like the code confuses varName and varValue, and therefore handles the scenario of a missing environment variable incorrectly. I think I was able to figure out the intent, but please review for correctness.

(Triggered by internal security audit and Fortify analysis.)