### PR TITLE
Use ROOT locale when lowercasing strings

### DIFF
--- a/src/main/java/com/threerings/getdown/data/Resource.java
+++ b/src/main/java/com/threerings/getdown/data/Resource.java
@@ -12,6 +12,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 
@@ -207,7 +208,7 @@ public class Resource implements Comparable<Resource>
         throws IOException
     {
         File file;
-        if (_local.toString().toLowerCase().endsWith(Application.CONFIG_FILE)) {
+        if (_local.toString().toLowerCase(Locale.ROOT).endsWith(Application.CONFIG_FILE)) {
             file = _local;
         } else {
             file = _localNew.exists() ? _localNew : _local;

--- a/src/main/java/com/threerings/getdown/util/Config.java
+++ b/src/main/java/com/threerings/getdown/util/Config.java
@@ -51,8 +51,8 @@ public class Config
     public static ParseOpts createOpts (boolean checkPlatform) {
         ParseOpts opts = new ParseOpts();
         if (checkPlatform) {
-            opts.osname = StringUtil.deNull(System.getProperty("os.name")).toLowerCase();
-            opts.osarch = StringUtil.deNull(System.getProperty("os.arch")).toLowerCase();
+            opts.osname = StringUtil.deNull(System.getProperty("os.name")).toLowerCase(Locale.ROOT);
+            opts.osarch = StringUtil.deNull(System.getProperty("os.arch")).toLowerCase(Locale.ROOT);
         }
         return opts;
     }
@@ -360,7 +360,7 @@ public class Config
     /** A helper function for {@link #checkQualifiers}. */
     protected static boolean checkQualifier (String qual, String osname, String osarch)
     {
-        String[] bits = qual.trim().toLowerCase().split("-");
+        String[] bits = qual.trim().toLowerCase(Locale.ROOT).split("-");
         String os = bits[0], arch = (bits.length > 1) ? bits[1] : "";
         return (osname.indexOf(os) != -1) && (osarch.indexOf(arch) != -1);
     }

--- a/src/main/java/com/threerings/getdown/util/LaunchUtil.java
+++ b/src/main/java/com/threerings/getdown/util/LaunchUtil.java
@@ -9,6 +9,8 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.util.Locale;
+
 import com.samskivert.util.RunAnywhere;
 import com.samskivert.util.StringUtil;
 
@@ -182,7 +184,7 @@ public class LaunchUtil
      */
     public static boolean mustMonitorChildren ()
     {
-        String osname = System.getProperty("os.name", "").toLowerCase();
+        String osname = System.getProperty("os.name", "").toLowerCase(Locale.ROOT);
         return (osname.indexOf("windows 98") != -1 || osname.indexOf("windows me") != -1);
     }
 


### PR DESCRIPTION
Not all locales lowercase the same way, so it's safest to specify a specific locale to use, instead of using the current system default.

(Triggered by internal security audit and Fortify analysis.)