### PR TITLE
Eliminate unchecked file.delete() return values

### DIFF
--- a/src/main/java/com/threerings/getdown/launcher/Getdown.java
+++ b/src/main/java/com/threerings/getdown/launcher/Getdown.java
@@ -706,7 +706,6 @@ public abstract class Getdown extends Thread
                 // clean up the patch file
                 if (!FileUtil.deleteHarder(prsrc.getLocal())) {
                     log.warning("Failed to delete '" + prsrc + "'.");
-                    prsrc.getLocal().deleteOnExit();
                 }
             }
         }

--- a/src/main/java/com/threerings/getdown/tools/Differ.java
+++ b/src/main/java/com/threerings/getdown/tools/Differ.java
@@ -22,10 +22,10 @@ import java.util.zip.ZipEntry;
 import java.security.MessageDigest;
 
 import com.samskivert.io.StreamUtil;
-
 import com.threerings.getdown.data.Application;
 import com.threerings.getdown.data.Digest;
 import com.threerings.getdown.data.Resource;
+import com.threerings.getdown.util.FileUtil;
 
 /**
  * Generates patch files between two particular revisions of an
@@ -137,8 +137,8 @@ public class Differ
                         File temp = rebuildJar(rsrc.getLocal());
                         jout.putNextEntry(new ZipEntry(rsrc.getPath() + Patcher.PATCH));
                         jarDiff(otemp, temp, jout);
-                        otemp.delete();
-                        temp.delete();
+                        FileUtil.deleteHarder(otemp);
+                        FileUtil.deleteHarder(temp);
                         continue;
                     }
                 }
@@ -162,7 +162,7 @@ public class Differ
             System.out.println("Created patch file: " + patch);
 
         } catch (IOException ioe) {
-            patch.delete();
+            FileUtil.deleteHarder(patch);
             throw ioe;
         }
     }

--- a/src/main/java/com/threerings/getdown/tools/Patcher.java
+++ b/src/main/java/com/threerings/getdown/tools/Patcher.java
@@ -78,7 +78,7 @@ public class Patcher
                     path = strip(path, DELETE);
                     System.out.println("Removing " + path + "...");
                     File target = new File(appdir, path);
-                    if (!target.delete()) {
+                    if (!FileUtil.deleteHarder(target)) {
                         System.err.println("Failure deleting '" + target + "'.");
                     }
 
@@ -134,7 +134,7 @@ public class Patcher
         JarDiffPatcher patcher = null;
 
         // make sure no stale old target is lying around to mess us up
-        otarget.delete();
+        FileUtil.deleteHarder(otarget);
 
         // pipe the contents of the patch into a file
         try (InputStream in = file.getInputStream(entry);
@@ -170,12 +170,8 @@ public class Patcher
 
         } finally {
             // clean up our temporary files
-            if (!patch.delete()) {
-                patch.deleteOnExit();
-            }
-            if (!otarget.delete()) {
-                otarget.deleteOnExit();
-            }
+            FileUtil.deleteHarder(patch);
+            FileUtil.deleteHarder(otarget);
         }
     }
 

--- a/src/main/java/com/threerings/getdown/util/FileUtil.java
+++ b/src/main/java/com/threerings/getdown/util/FileUtil.java
@@ -71,14 +71,18 @@ public class FileUtil
 
     /**
      * "Tries harder" to delete {@code file} than just calling {@code delete} on it. Presently this
-     * just means "try a second time if the first time fails." On Windows Vista, sometimes deletes
-     * fail but then succeed if you just try again. Given that delete failure is a rare occurance,
-     * we can implement this hacky workaround without any negative consequences for normal
-     * behavior.
+     * just means "try a second time if the first time fails, and if that fails then try to delete
+     * when the virtual machine terminates." On Windows Vista, sometimes deletes fail but then
+     * succeed if you just try again. Given that delete failure is a rare occurrence, we can
+     * implement this hacky workaround without any negative consequences for normal behavior.
      */
     public static boolean deleteHarder (File file) {
         // if at first you don't succeed... try, try again
-        return file.delete() || file.delete();
+        boolean deleted = (file.delete() || file.delete());
+        if (!deleted) {
+            file.deleteOnExit();
+        }
+        return deleted;
     }
 
     /**


### PR DESCRIPTION
Eliminates unchecked file.delete() return values. Also standardizes the way that files are deleted across the codebase.

Ignoring a method's return value can cause the program to overlook unexpected states and conditions.

(Triggered by internal security audit and Fortify analysis.)