### PR TITLE
Small DoS mitigation: add start delay sanity check

### DIFF
--- a/core/src/main/java/com/threerings/getdown/data/SysProps.java
+++ b/core/src/main/java/com/threerings/getdown/data/SysProps.java
@@ -70,10 +70,12 @@ public class SysProps
         return "launch".equals(System.getProperty("silent"));
     }
 
-    /** Specifies the a delay (in minutes) to wait before starting the update and install process.
+    /** Specifies the delay (in minutes) to wait before starting the update and install process.
+      * Minimum delay is 0 minutes, or no delay (negative values are rounded up to 0 minutes).
+      * Maximum delay is 1 day, or 1440 minutes (larger values are rounded down to 1 day).
       * Usage: {@code -Ddelay=N}. */
     public static int startDelay () {
-        return Integer.getInteger("delay", 0);
+        return Math.min(Math.max(Integer.getInteger("delay", 0), 0), 60 * 24);
     }
 
     /** If true, Getdown will not unpack {@code uresource} jars. Usage: {@code -Dno_unpack}. */

--- a/core/src/test/java/com/threerings/getdown/data/SysPropsTest.java
+++ b/core/src/test/java/com/threerings/getdown/data/SysPropsTest.java
@@ -11,16 +11,37 @@ import static org.junit.Assert.*;
 public class SysPropsTest {
 
     @After public void clearProps () {
+        System.clearProperty("delay");
         System.clearProperty("appbase_domain");
         System.clearProperty("appbase_override");
     }
 
-    public static String[] APPBASES = {
+    private static final String[] APPBASES = {
         "http://foobar.com/myapp",
         "https://foobar.com/myapp",
         "http://foobar.com:8080/myapp",
         "https://foobar.com:8080/myapp"
     };
+
+    @Test public void testStartDelay () {
+
+        assertEquals(0, SysProps.startDelay());
+
+        System.setProperty("delay", "x");
+        assertEquals(0, SysProps.startDelay());
+
+        System.setProperty("delay", "-7");
+        assertEquals(0, SysProps.startDelay());
+
+        System.setProperty("delay", "7");
+        assertEquals(7, SysProps.startDelay());
+
+        System.setProperty("delay", "1440");
+        assertEquals(1440, SysProps.startDelay());
+
+        System.setProperty("delay", "1441");
+        assertEquals(1440, SysProps.startDelay());
+    }
 
     @Test public void testAppbaseDomain () {
         System.setProperty("appbase_domain", "https://barbaz.com");


### PR DESCRIPTION
These types of denial of service issues are more common in web applications, but even here an attacker could tie up local system resources indefinitely by specifying a very large start delay.

(Triggered by internal security audit and Fortify analysis.)