### PR TITLE
Remove legacy Getdown.main( ) method

### DIFF
--- a/launcher/src/main/java/com/threerings/getdown/launcher/Getdown.java
+++ b/launcher/src/main/java/com/threerings/getdown/launcher/Getdown.java
@@ -69,12 +69,6 @@ import static com.threerings.getdown.Log.log;
 public abstract class Getdown extends Thread
     implements Application.StatusDisplay, RotatingBackgrounds.ImageLoader
 {
-    public static void main (String[] args)
-    {
-        // legacy support
-        GetdownApp.main(args);
-    }
-
     public Getdown (File appDir, String appId)
     {
         this(appDir, appId, null, null, null);


### PR DESCRIPTION
This method was apparently deprecated 12 years ago, when GetdownApp.main( ) was added. The immediate motivation is to eliminate some of the security noise around this method being a source of untrusted data, but in a more general sense it also probably makes sense to clean it up after not being used for so long.

(Triggered by internal security audit and Fortify analysis.)