### PR TITLE
Avoid calling overridable function from constructor

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -16,13 +16,13 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.8.1</version>
+      <version>4.12</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>1.10.19</version>
+      <version>2.22.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/core/src/main/java/com/threerings/getdown/data/Application.java
+++ b/core/src/main/java/com/threerings/getdown/data/Application.java
@@ -36,7 +36,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * Parses and provide access to the information contained in the <code>getdown.txt</code>
  * configuration file.
  */
-public class Application
+public final class Application
 {
     /** The name of our configuration file. */
     public static final String CONFIG_FILE = "getdown.txt";

--- a/core/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/core/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/launcher/src/main/java/com/threerings/getdown/launcher/AbortPanel.java
+++ b/launcher/src/main/java/com/threerings/getdown/launcher/AbortPanel.java
@@ -28,14 +28,14 @@ import static com.threerings.getdown.Log.log;
 /**
  * Displays a confirmation that the user wants to abort installation.
  */
-public class AbortPanel extends JFrame
+public final class AbortPanel extends JFrame
     implements ActionListener
 {
     public AbortPanel (Getdown getdown, ResourceBundle msgs)
     {
         _getdown = getdown;
         _msgs = msgs;
- 
+
         setLayout(new VGroupLayout());
         setResizable(false);
         setTitle(get("m.abort_title"));

--- a/launcher/src/main/java/com/threerings/getdown/launcher/ProxyPanel.java
+++ b/launcher/src/main/java/com/threerings/getdown/launcher/ProxyPanel.java
@@ -30,7 +30,7 @@ import static com.threerings.getdown.Log.log;
  * Displays an interface with which the user can configure their proxy
  * settings.
  */
-public class ProxyPanel extends JPanel
+public final class ProxyPanel extends JPanel
     implements ActionListener
 {
     public ProxyPanel (Getdown getdown, ResourceBundle msgs)

--- a/launcher/src/main/java/com/threerings/getdown/launcher/RotatingBackgrounds.java
+++ b/launcher/src/main/java/com/threerings/getdown/launcher/RotatingBackgrounds.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 import static com.threerings.getdown.Log.log;
 
-public class RotatingBackgrounds
+public final class RotatingBackgrounds
 {
     public interface ImageLoader {
         /** Loads and returns the image with the supplied path. */

--- a/launcher/src/main/java/com/threerings/getdown/launcher/StatusPanel.java
+++ b/launcher/src/main/java/com/threerings/getdown/launcher/StatusPanel.java
@@ -36,7 +36,7 @@ import static com.threerings.getdown.Log.log;
 /**
  * Displays download and patching status.
  */
-public class StatusPanel extends JComponent
+public final class StatusPanel extends JComponent
     implements ImageObserver
 {
     public StatusPanel (ResourceBundle msgs)


### PR DESCRIPTION
When a constructor calls an overridable function, it may allow an attacker to access the "this" reference prior to the object being fully initialized, which can in turn lead to a vulnerability.

Application -> getLocalPath
ProxyPanel -> get
AbortPanel -> get
RotatingBackgrounds -> makeEmpty

(Triggered by internal security audit and Fortify analysis.)