### PR TITLE
Introduced a new option called sysargs to bootstrap.properties...

### DIFF
--- a/core/src/main/java/com/threerings/getdown/data/Application.java
+++ b/core/src/main/java/com/threerings/getdown/data/Application.java
@@ -1475,7 +1475,7 @@ public class Application
      *
      * @param sigVersion if {@code 0} no validation will be performed, if {@code > 0} then this
      * should indicate the version of the digest file being validated which indicates which
-     * algorithm to use to verify the signature. See {@link Digest#VESRION}.
+     * algorithm to use to verify the signature. See {@link Digest#VERSION}.
      */
     protected void downloadControlFile (String path, int sigVersion)
         throws IOException

--- a/core/src/main/java/com/threerings/getdown/data/EnvConfig.java
+++ b/core/src/main/java/com/threerings/getdown/data/EnvConfig.java
@@ -53,7 +53,7 @@ public final class EnvConfig {
         String appDir = null, appDirProv = null;
         String appId = null, appIdProv = null;
         String appBase = null, appBaseProv = null;
-
+        String[] sysargs;
         // start with bootstrap.properties config, if avaialble
         try {
             ResourceBundle bundle = ResourceBundle.getBundle("bootstrap");
@@ -74,6 +74,22 @@ public final class EnvConfig {
                 appBase = bundle.getString("appbase");
                 appBaseProv = "bootstrap.properties";
             }
+
+            // Set system properties. Should be in the form:
+            // sysargs = [key1]:[val1] , [key2]:[val2], [key3]
+            if (bundle.containsKey("sysargs")) {
+                sysargs = bundle.getString("sysargs").split(",");
+
+                for (String sysarg : sysargs) {
+                    String[] arg_value = sysarg.trim().split(":", 2);
+                    if(arg_value.length == 2){
+                        System.setProperty(arg_value[0], arg_value[1]);
+                    }else if(arg_value.length == 1) {
+                        System.setProperty(arg_value[0], "");
+                    }
+                }
+            }
+
         } catch (MissingResourceException e) {
             // bootstrap.properties is optional; no need for a warning
         }


### PR DESCRIPTION
Usage: sysargs = [key1]:[val1], [key2]:[val2], [key3]

This change allows Getdown to set system properties during the bootstrap setup by adding the above line to bootstrap.properties

This change is to further the flexibility of the new bootstrap feature. Personally I'm using it to enable "-Dsilent" without having to create a separate launcher to run Getdown with that property.

I've tried to keep the change minimal and I hope you can integrate this feature into Getdown.

Thanks! 