### PR TITLE
update Java VM: checking Java version again after getdown.txt has been re-fetched.

### DIFF
--- a/launcher/src/main/java/com/threerings/getdown/launcher/Getdown.java
+++ b/launcher/src/main/java/com/threerings/getdown/launcher/Getdown.java
@@ -399,6 +399,7 @@ public abstract class Getdown extends Thread
             _readyToInstall = false;
 
             //setStep(Step.START);
+            boolean javavm_updated = false;
             for (int ii = 0; ii < MAX_LOOPS; ii++) {
                 // if we aren't running in a JVM that meets our version requirements, either
                 // complain or attempt to download and install the appropriate version
@@ -409,7 +410,7 @@ public abstract class Getdown extends Thread
                     setStep(Step.UPDATE_JAVA);
                     _enableTracking = true; // always track JVM downloads
                     try {
-                        updateJava();
+                    	javavm_updated = updateJava();
                     } finally {
                         _enableTracking = false;
                     }
@@ -462,6 +463,9 @@ public abstract class Getdown extends Thread
                     // now we'll loop back and try it all again
                     continue;
                 }
+                else if (!_app.haveValidJavaVersion() && !javavm_updated) 
+                	continue;
+                
 
                 // if we were downloaded in full from another service (say, Steam), we may
                 // not have unpacked all of our resources yet
@@ -571,7 +575,7 @@ public abstract class Getdown extends Thread
      * Downloads and installs an Java VM bundled with the application. This is called if we are not
      * running with the necessary Java version.
      */
-    protected void updateJava ()
+    protected boolean updateJava ()
         throws IOException
     {
         Resource vmjar = _app.getJavaVMResource();
@@ -607,6 +611,7 @@ public abstract class Getdown extends Thread
         }
 
         reportTrackingEvent("jvm_complete", -1);
+        return true;
     }
 
     /**


### PR DESCRIPTION
Typical use case is a security patch, were a new java patch (java_windows.jar) is put on server side and java_min_version updated accordingly in getdown.txt

Currently the new virtual machine will be downloaded only after a second getdown launch.
This pull request fixes this.
Here a launcher log-file with the patch in action:

2018/11/28 15:20:24:700 INFO Using appdir from command line: C:\Users\pb00067\getdown
2018/11/28 15:20:24:724 INFO ------------------ VM Info ------------------
2018/11/28 15:20:24:725 INFO -- OS Name: Windows 10
2018/11/28 15:20:24:725 INFO -- OS Arch: amd64
2018/11/28 15:20:24:725 INFO -- OS Vers: 10.0
2018/11/28 15:20:24:725 INFO -- Java Vers: 1.8.0_192
2018/11/28 15:20:24:725 INFO -- Java Home: C:\Program Files\Java\jre1.8.0_192
2018/11/28 15:20:24:725 INFO -- User Name: pb00067
2018/11/28 15:20:24:725 INFO -- User Home: C:\Users\pb00067
2018/11/28 15:20:24:725 INFO -- Cur dir: C:\Users\pb00067\getdown
2018/11/28 15:20:24:725 INFO ---------------------------------------------
2018/11/28 15:20:24:825 INFO Getdown starting [version=1.8.2, built=2018-11-27 13:36]
2018/11/28 15:20:24:829 INFO Failed to find proxy settings in Windows registry [error=java.lang.UnsatisfiedLinkError: no jRegistryKey in java.library.path]
2018/11/28 15:20:24:841 INFO ---------------- Proxy Info -----------------
2018/11/28 15:20:24:841 INFO -- Proxy Host: null
2018/11/28 15:20:24:841 INFO -- Proxy Port: null
2018/11/28 15:20:24:841 INFO ---------------------------------------------
2018/11/28 15:20:24:882 INFO Able to lock for updates: true
2018/11/28 15:20:24:887 INFO Checking Java version [current=11000300, wantMin=11000300, wantMax=0]
2018/11/28 15:20:24:891 INFO Checking version of unpacked JVM [vers=11000300].
2018/11/28 15:20:25:005 INFO Verifying application: http://pbzcislx005:8080/cis/getdown/
2018/11/28 15:20:25:005 INFO Version: -1
2018/11/28 15:20:25:005 INFO Class: com.wuerth.phoenix.cis.ulc.client.CisStandaloneLauncher
2018/11/28 15:20:25:006 INFO Dropping status 'm.validating'.
2018/11/28 15:20:25:045 INFO Attempting to refetch 'digest.txt' from 'http://pbzcislx005:8080/cis/getdown/digest.txt'.
2018/11/28 15:20:25:113 INFO No signing certs, not verifying digest.txt [path=digest.txt]
2018/11/28 15:20:25:121 INFO Attempting to refetch 'digest2.txt' from 'http://pbzcislx005:8080/cis/getdown/digest2.txt'.
2018/11/28 15:20:25:141 INFO No signing certs, not verifying digest.txt [path=digest2.txt]
2018/11/28 15:20:25:151 INFO Unversioned digest changed. Revalidating...
2018/11/28 15:20:25:168 INFO Resource failed digest check [rsrc=getdown.txt, computed=0b08745087ef8a3b6efd60fba425c5f5905cfaac783bee6fae0081dd2a14b3cc, expected=d705583abec9a3adcaf669746f34cad47be6c577abe8bc8a76b9f9a35e09aff7]
2018/11/28 15:20:25:168 INFO Attempting to refetch 'getdown.txt' from 'http://pbzcislx005:8080/cis/getdown/getdown.txt'.
2018/11/28 15:20:25:199 INFO Attempting to refetch 'digest.txt' from 'http://pbzcislx005:8080/cis/getdown/digest.txt'.
2018/11/28 15:20:25:226 INFO No signing certs, not verifying digest.txt [path=digest.txt]
2018/11/28 15:20:25:234 INFO Attempting to refetch 'digest2.txt' from 'http://pbzcislx005:8080/cis/getdown/digest2.txt'.
2018/11/28 15:20:25:253 INFO No signing certs, not verifying digest.txt [path=digest2.txt]
2018/11/28 15:20:25:561 INFO Verified resources [count=6, size=2908k, duration=288ms]
**2018/11/28 15:20:25:561 INFO Checking Java version [current=11000300, wantMin=11000400, wantMax=0]
2018/11/28 15:20:25:563 INFO Checking version of unpacked JVM [vers=11000300].
2018/11/28 15:20:25:563 INFO Checking Java version [current=11000300, wantMin=11000400, wantMax=0]
2018/11/28 15:20:25:564 INFO Checking version of unpacked JVM [vers=11000300].
2018/11/28 15:20:25:564 INFO Attempting to update Java VM...
2018/11/28 15:20:25:581 INFO Downloading 1 resources [totalBytes=26710429, maxConcurrent=2]
2018/11/28 15:20:25:585 INFO Downloading resource [url=http://pbzcislx005:8080/cis/getdown/java_windows.jar, size=26710429]
2018/11/28 15:20:27:546 INFO - C:\Users\pb00067\getdown\java_vm.jar_new
2018/11/28 15:20:29:099 INFO Regenerating classes.jsa for C:\Users\pb00067\getdown\java_vm\bin\javaw.exe...
2018/11/28 15:20:29:124 INFO Checking Java version [current=11000300, wantMin=11000400, wantMax=0]
2018/11/28 15:20:29:126 INFO Checking version of unpacked JVM [vers=11000400].**
2018/11/28 15:20:29:126 INFO Verifying application: http://pbzcislx005:8080/cis/getdown/
2018/11/28 15:20:29:126 INFO Version: -1
2018/11/28 15:20:29:126 INFO Class: com.wuerth.phoenix.cis.ulc.client.CisStandaloneLauncher
2018/11/28 15:20:29:127 INFO Attempting to refetch 'digest.txt' from 'http://pbzcislx005:8080/cis/getdown/digest.txt'.
2018/11/28 15:20:29:134 INFO No signing certs, not verifying digest.txt [path=digest.txt]
2018/11/28 15:20:29:141 INFO Attempting to refetch 'digest2.txt' from 'http://pbzcislx005:8080/cis/getdown/digest2.txt'.
2018/11/28 15:20:29:148 INFO No signing certs, not verifying digest.txt [path=digest2.txt]
2018/11/28 15:20:29:161 INFO Verified resources [count=6, size=2908k, duration=1ms]
2018/11/28 15:20:29:162 INFO Checking Java version [current=1080192, wantMin=11000400, wantMax=0]
2018/11/28 15:20:29:164 INFO Checking version of unpacked JVM [vers=11000400].
2018/11/28 15:20:29:164 INFO Installing 0 downloaded resources:
2018/11/28 15:20:29:164 INFO Install completed.
2018/11/28 15:20:29:168 INFO Didn't find any custom environment variables, not setting any.
2018/11/28 15:20:29:169 INFO Running C:\Users\pb00067\getdown\java_vm\bin\javaw.exe