### PR TITLE
Use -Dthread_pool_size to determine max_concurrent_downloads

### DIFF
--- a/core/src/main/java/com/threerings/getdown/data/Application.java
+++ b/core/src/main/java/com/threerings/getdown/data/Application.java
@@ -717,7 +717,12 @@ public class Application
         _codeCacheRetentionDays = config.getInt("code_cache_retention_days", 7);
 
         // maximum simultaneous downloads
-        _maxConcDownloads = Math.max(1, config.getInt("max_concurrent_downloads", 2));
+        int userConcDownloads = config.getInt("max_concurrent_downloads", 2);
+        if(userConcDownloads==-1){
+            _maxConcDownloads = SysProps.threadPoolSize();
+        } else {
+            _maxConcDownloads = Math.max(1, userConcDownloads);
+        }
 
         // parse and return our application config
         UpdateInterface ui = new UpdateInterface(config);


### PR DESCRIPTION
Setting max_concurrent_downloads=-1 will force the downloader to use the number of threads defined by -Dthread_pool_size

After some tests it looks like limiting the number of threads to the number of virtual cores of the system will optimise the download speed. Since threadPoolSize defaults to "num_of_cores - 1" anyway, we might as well reuse that.

Alternatively, we can default max_concurrent_downloads to use threadPoolSize to avoid having to use max_concurrent_downloads=-1. This would make sense because I'd reckon that if someone uses -DthreadPoolSize to limit the number of concurrent verifications, then they probably also want to limit the number of concurrent downloads by the same amount.  