### PR TITLE
update Java VM: Checking Java version after getdown.txt has been re-fetched.

### DIFF
--- a/launcher/src/main/java/com/threerings/getdown/launcher/Getdown.java
+++ b/launcher/src/main/java/com/threerings/getdown/launcher/Getdown.java
@@ -400,21 +400,6 @@ public abstract class Getdown extends Thread
 
             //setStep(Step.START);
             for (int ii = 0; ii < MAX_LOOPS; ii++) {
-                // if we aren't running in a JVM that meets our version requirements, either
-                // complain or attempt to download and install the appropriate version
-                if (!_app.haveValidJavaVersion()) {
-                    // download and install the necessary version of java, then loop back again and
-                    // reverify everything; if we can't download java; we'll throw an exception
-                    log.info("Attempting to update Java VM...");
-                    setStep(Step.UPDATE_JAVA);
-                    _enableTracking = true; // always track JVM downloads
-                    try {
-                        updateJava();
-                    } finally {
-                        _enableTracking = false;
-                    }
-                    continue;
-                }
 
                 // make sure we have the desired version and that the metadata files are valid...
                 setStep(Step.VERIFY_METADATA);
@@ -460,6 +445,22 @@ public abstract class Getdown extends Thread
                     }
 
                     // now we'll loop back and try it all again
+                    continue;
+                }
+                
+                // if we aren't running in a JVM that meets our version requirements, either
+                // complain or attempt to download and install the appropriate version
+                if (!_app.haveValidJavaVersion()) {
+                    // download and install the necessary version of java, then loop back again and
+                    // reverify everything; if we can't download java; we'll throw an exception
+                    log.info("Attempting to update Java VM...");
+                    setStep(Step.UPDATE_JAVA);
+                    _enableTracking = true; // always track JVM downloads
+                    try {
+                        updateJava();
+                    } finally {
+                        _enableTracking = false;
+                    }
                     continue;
                 }
 


### PR DESCRIPTION
Typical use case is a security patch, were a new java patch (java_windows.jar) is put on server side and java_min_version updated accordingly in getdown.txt

Currently the new virtual machine will be downloaded only after a second getdown launch. 
This can be to late when a critical security issue has to be resolved asap.
This pull request fixes this.

In contrast to #167 this merely moves the update-java section down some blocks, so its less invasive.

Here a sample launcher.log:
```
2018/11/29 09:32:51:632 INFO Using appdir from command line: C:\Users\pb00067\getdown
2018/11/29 09:32:51:654 INFO ------------------ VM Info ------------------
2018/11/29 09:32:51:654 INFO -- OS Name: Windows 10
2018/11/29 09:32:51:654 INFO -- OS Arch: amd64
2018/11/29 09:32:51:654 INFO -- OS Vers: 10.0
2018/11/29 09:32:51:654 INFO -- Java Vers: 1.8.0_192
2018/11/29 09:32:51:654 INFO -- Java Home: C:\Program Files\Java\jre1.8.0_192
2018/11/29 09:32:51:654 INFO -- User Name: pb00067
2018/11/29 09:32:51:654 INFO -- User Home: C:\Users\pb00067
2018/11/29 09:32:51:654 INFO -- Cur dir: C:\Users\pb00067\getdown
2018/11/29 09:32:51:654 INFO ---------------------------------------------
2018/11/29 09:32:51:862 INFO Getdown starting [version=1.8.2, built=2018-11-27 13:36]
2018/11/29 09:32:51:872 INFO Failed to find proxy settings in Windows registry [error=java.lang.UnsatisfiedLinkError: no jRegistryKey in java.library.path]
2018/11/29 09:32:51:918 INFO ---------------- Proxy Info -----------------
2018/11/29 09:32:51:918 INFO -- Proxy Host: null
2018/11/29 09:32:51:918 INFO -- Proxy Port: null
2018/11/29 09:32:51:918 INFO ---------------------------------------------
2018/11/29 09:32:52:059 INFO Able to lock for updates: true
2018/11/29 09:32:52:221 INFO Verifying application: http://pbzcislx005:8080/cis/getdown/
2018/11/29 09:32:52:221 INFO Version: -1
2018/11/29 09:32:52:221 INFO Class: com.wuerth.phoenix.cis.ulc.client.CisStandaloneLauncher
2018/11/29 09:32:52:222 INFO Dropping status 'm.validating'.
2018/11/29 09:32:52:257 INFO Attempting to refetch 'digest.txt' from 'http://pbzcislx005:8080/cis/getdown/digest.txt'.
2018/11/29 09:32:52:692 INFO No signing certs, not verifying digest.txt [path=digest.txt]
2018/11/29 09:32:52:704 INFO Attempting to refetch 'digest2.txt' from 'http://pbzcislx005:8080/cis/getdown/digest2.txt'.
2018/11/29 09:32:52:778 INFO No signing certs, not verifying digest.txt [path=digest2.txt]
2018/11/29 09:32:52:790 INFO Unversioned digest changed. Revalidating...
2018/11/29 09:32:52:807 INFO Resource failed digest check [rsrc=getdown.txt, computed=d705583abec9a3adcaf669746f34cad47be6c577abe8bc8a76b9f9a35e09aff7, expected=b402695a3a66b56b046bd710ef035fc5aad4e2c75a50587f07ee0efc4808dbff]
2018/11/29 09:32:52:808 INFO Attempting to refetch 'getdown.txt' from 'http://pbzcislx005:8080/cis/getdown/getdown.txt'.
2018/11/29 09:32:52:836 INFO Attempting to refetch 'digest.txt' from 'http://pbzcislx005:8080/cis/getdown/digest.txt'.
2018/11/29 09:32:52:856 INFO No signing certs, not verifying digest.txt [path=digest.txt]
2018/11/29 09:32:52:864 INFO Attempting to refetch 'digest2.txt' from 'http://pbzcislx005:8080/cis/getdown/digest2.txt'.
2018/11/29 09:32:52:888 INFO No signing certs, not verifying digest.txt [path=digest2.txt]
2018/11/29 09:32:53:317 INFO Verified resources [count=6, size=2908k, duration=410ms]
2018/11/29 09:32:53:319 INFO Checking Java version [current=1080192, wantMin=11000500, wantMax=0]
2018/11/29 09:32:53:320 INFO Checking version of unpacked JVM [vers=11000400].
2018/11/29 09:32:53:320 INFO Attempting to update Java VM...
2018/11/29 09:32:53:399 INFO Downloading 1 resources [totalBytes=26710429, maxConcurrent=2]
2018/11/29 09:32:53:464 INFO Downloading resource [url=http://pbzcislx005:8080/cis/getdown/java_windows.jar, size=26710429]
2018/11/29 09:32:55:946 INFO - C:\Users\pb00067\getdown\java_vm.jar_new
2018/11/29 09:32:57:481 INFO Regenerating classes.jsa for C:\Users\pb00067\getdown\java_vm\bin\javaw.exe...
2018/11/29 09:32:57:501 INFO Verifying application: http://pbzcislx005:8080/cis/getdown/
2018/11/29 09:32:57:501 INFO Version: -1
2018/11/29 09:32:57:501 INFO Class: com.wuerth.phoenix.cis.ulc.client.CisStandaloneLauncher
2018/11/29 09:32:57:501 INFO Attempting to refetch 'digest.txt' from 'http://pbzcislx005:8080/cis/getdown/digest.txt'.
2018/11/29 09:32:57:511 INFO No signing certs, not verifying digest.txt [path=digest.txt]
2018/11/29 09:32:57:522 INFO Attempting to refetch 'digest2.txt' from 'http://pbzcislx005:8080/cis/getdown/digest2.txt'.
2018/11/29 09:32:57:532 INFO No signing certs, not verifying digest.txt [path=digest2.txt]
2018/11/29 09:32:57:542 INFO Verified resources [count=6, size=2908k, duration=0ms]
2018/11/29 09:32:57:550 INFO Checking Java version [current=1080192, wantMin=11000500, wantMax=0]
2018/11/29 09:32:57:550 INFO Checking version of unpacked JVM [vers=11000500].
2018/11/29 09:32:57:550 INFO Installing 0 downloaded resources:
2018/11/29 09:32:57:550 INFO Install completed.
2018/11/29 09:32:57:672 INFO Didn't find any custom environment variables, not setting any.
2018/11/29 09:32:57:673 INFO Running C:\Users\pb00067\getdown\java_vm\bin\javaw.exe
  -classpath
```
