### PR TITLE
Fix for #112, installing a newer JVM leaves parts of the old JVM

### DIFF
--- a/core/src/main/java/com/threerings/getdown/data/Resource.java
+++ b/core/src/main/java/com/threerings/getdown/data/Resource.java
@@ -254,20 +254,21 @@ public class Resource implements Comparable<Resource>
     /**
      * Installs the {@code getLocalNew} version of this resource to {@code getLocal}.
      */
-    public void install () throws IOException {
+    public void install (boolean cleanExistingDirs) throws IOException {
         File source = getLocalNew(), dest = getLocal();
         log.info("- " + source);
         if (!FileUtil.renameTo(source, dest)) {
             throw new IOException("Failed to rename " + source + " to " + dest);
         }
-        applyAttrs();
+        applyAttrs(cleanExistingDirs);
         markAsValid();
     }
+
 
     /**
      * Unpacks this resource file into the directory that contains it.
      */
-    public void unpack () throws IOException
+    public void unpack (boolean cleanExistingDirs) throws IOException
     {
         // sanity check
         if (!_isJar && !_isPacked200Jar) {
@@ -275,26 +276,35 @@ public class Resource implements Comparable<Resource>
         }
         if (_isJar) {
             try (JarFile jar = new JarFile(_local)) {
-                FileUtil.unpackJar(jar, _unpacked);
+                FileUtil.unpackJar(jar, _unpacked, cleanExistingDirs);
             }
         } else {
             FileUtil.unpackPacked200Jar(_local, _unpacked);
         }
+    }
+    
+    public void unpack () throws IOException
+    {
+    	unpack(false);
     }
 
     /**
      * Applies this resources special attributes: unpacks this resource if needed, marks it as
      * executable if needed.
      */
-    public void applyAttrs () throws IOException {
+    public void applyAttrs (boolean cleanExistingDirs) throws IOException {
         if (shouldUnpack()) {
-            unpack();
+            unpack(cleanExistingDirs);
         }
         if (_attrs.contains(Attr.EXEC)) {
             FileUtil.makeExecutable(_local);
         }
     }
 
+    public void applyAttrs () throws IOException {
+    	applyAttrs(false);
+    }
+    
     /**
      * Wipes this resource file along with any "validated" marker file that may be associated with
      * it.

--- a/core/src/main/java/com/threerings/getdown/util/FileUtil.java
+++ b/core/src/main/java/com/threerings/getdown/util/FileUtil.java
@@ -94,9 +94,25 @@ public class FileUtil
     /**
      * Unpacks the specified jar file into the specified target directory.
      */
-    public static void unpackJar (JarFile jar, File target) throws IOException
+    public static void unpackJar (JarFile jar, File target, boolean cleanExistingDirs) throws IOException
     {
         Enumeration<?> entries = jar.entries();
+        if (cleanExistingDirs)
+        {
+			while (entries.hasMoreElements()) {
+				JarEntry entry = (JarEntry) entries.nextElement();
+				if (entry.isDirectory()) {
+					File efile = new File(target, entry.getName());
+					 if (efile.exists()) {
+						 for (File f : efile.listFiles()) {
+							 if (!f.isDirectory())
+								 f.delete();
+						 }
+					 }
+				}
+			}
+        }
+        entries = jar.entries();
         while (entries.hasMoreElements()) {
             JarEntry entry = (JarEntry)entries.nextElement();
             File efile = new File(target, entry.getName());

--- a/launcher/src/main/java/com/threerings/getdown/launcher/Getdown.java
+++ b/launcher/src/main/java/com/threerings/getdown/launcher/Getdown.java
@@ -116,7 +116,7 @@ public abstract class Getdown extends Thread
         } else if (_readyToInstall) {
             log.info("Installing " + _toInstallResources.size() + " downloaded resources:");
             for (Resource resource : _toInstallResources) {
-                resource.install();
+                resource.install(false);
             }
             _toInstallResources.clear();
             _readyToInstall = false;
@@ -589,7 +589,7 @@ public abstract class Getdown extends Thread
         reportTrackingEvent("jvm_unpack", -1);
 
         updateStatus("m.unpacking_java");
-        vmjar.install();
+        vmjar.install(true);
 
         // these only run on non-Windows platforms, so we use Unix file separators
         String localJavaDir = LaunchUtil.LOCAL_JAVA_DIR + "/";


### PR DESCRIPTION
Cleans content of each found directory when unpacking a new java_vm.

Disclaimer.: fixes the problem when java_[os].jar was build using standard jar and not when it was made using pack200. P.S.:  pack200 is deprecated https://openjdk.java.net/jeps/336  so probably we need no patch for this special use-case.