### PR TITLE
Use nresource=[native jar] to use native jars

### DIFF
--- a/core/src/main/java/com/threerings/getdown/classpath/ClassPaths.java
+++ b/core/src/main/java/com/threerings/getdown/classpath/ClassPaths.java
@@ -17,7 +17,6 @@ import com.threerings.getdown.data.Resource;
 
 public class ClassPaths
 {
-    static final String CACHE_DIR = ".cache";
 
     /**
      * Builds either a default or cached classpath based on {@code app}'s configuration.
@@ -48,21 +47,18 @@ public class ClassPaths
      */
     public static ClassPath buildCachedClassPath (Application app) throws IOException
     {
-        File cacheDir = new File(app.getAppDir(), CACHE_DIR);
+        File codeCacheDir = new File(app.getAppDir(), Application.CACHE_DIR + "/code");
+
         // a negative value of code_cache_retention_days allows to clean up the cache forcefully
-        if (app.getCodeCacheRetentionDays() <= 0) {
-            runGarbageCollection(app, cacheDir);
+        if (app.getCodeCacheRetentionDays() != 0) {
+            runGarbageCollection(app, codeCacheDir);
         }
 
-        ResourceCache cache = new ResourceCache(cacheDir);
-        LinkedHashSet<File> classPathEntries = new LinkedHashSet<File>();
+        ResourceCache cache = new ResourceCache(codeCacheDir);
+        LinkedHashSet<File> classPathEntries = new LinkedHashSet<>();
         for (Resource resource: app.getActiveCodeResources()) {
             File entry = cache.cacheFile(resource.getFinalTarget(), app.getDigest(resource));
             classPathEntries.add(entry);
-        }
-
-        if (app.getCodeCacheRetentionDays() > 0) {
-            runGarbageCollection(app, cacheDir);
         }
 
         return new ClassPath(classPathEntries);

--- a/core/src/main/java/com/threerings/getdown/classpath/NativeLibPath.java
+++ b/core/src/main/java/com/threerings/getdown/classpath/NativeLibPath.java
@@ -1,0 +1,83 @@
+package com.threerings.getdown.classpath;
+
+import com.threerings.getdown.classpath.cache.GarbageCollector;
+import com.threerings.getdown.classpath.cache.ResourceCache;
+import com.threerings.getdown.data.Application;
+import com.threerings.getdown.data.Resource;
+import com.threerings.getdown.util.FileUtil;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.jar.JarFile;
+import static com.threerings.getdown.Log.log;
+
+/**
+ * Similar to {@link ClassPath}, except used to represent directories containing native libraries instead.
+ */
+public class NativeLibPath extends ClassPath {
+
+    public NativeLibPath(LinkedHashSet<File> entries) {
+        super(entries);
+    }
+
+    /**
+     * Builds a {@link NativeLibPath} instance by first caching all native jars (indicated by
+     * nresource=[native jar]), unpacking them, and referencing the locations of each of the unpacked files.
+     * Also performs garbage collection similar to {@link ClassPaths#buildCachedClassPath}
+     *
+     * @param app                   used to determine native jars and related information
+     * @param addCurrentLibraryPath if true, it adds the locations referenced by
+     *                              {@code System.getProperty("java.library.path")} as well
+     */
+    public static NativeLibPath buildLibsPath(Application app, boolean addCurrentLibraryPath) throws IOException {
+        List<Resource> resources = app.getNativeJars();
+        String[] curPaths = System.getProperty("java.library.path").split(File.pathSeparator);
+        LinkedHashSet<File> nativedirs = new LinkedHashSet<>();
+
+        File nativeCacheDir = new File(app.getAppDir(), Application.CACHE_DIR + "/native");
+        ResourceCache cache = new ResourceCache(nativeCacheDir);
+
+        // negative value forces total garbage collection, 0 avoids garbage collection at all
+        if (app.getCodeCacheRetentionDays() != 0) {
+            runGarbageCollection(app, nativeCacheDir);
+        }
+
+        for (Resource resource : resources) {
+            // Use untruncated directory names because in the off chance that two native jars share a directory AND
+            // contain files with the same names, we'll get overwriting issues when unpacking
+            File cachedFile = cache.cacheFile(resource.getFinalTarget(), app.getDigest(resource), true);
+
+            if (!getUnpackedIndicator(cachedFile).exists()) {
+                try {
+                    FileUtil.unpackJar(new JarFile(cachedFile), cachedFile.getParentFile(), false);
+                    getUnpackedIndicator(cachedFile).createNewFile();
+                } catch (IOException ioe) {
+                    log.warning("Failed to unpack native jar", "File", cachedFile.getAbsolutePath(), ioe);
+                    // Keep going and unpack the other jars...
+                }
+            }
+
+            nativedirs.add(cachedFile.getParentFile());
+        }
+
+        if (addCurrentLibraryPath) {
+            for (String path : curPaths) {
+                nativedirs.add(new File(path));
+            }
+        }
+
+        return new NativeLibPath(nativedirs);
+    }
+
+    private static void runGarbageCollection(Application app, File nativeCacheDir) {
+        long retainMillis = TimeUnit.DAYS.toMillis(app.getCodeCacheRetentionDays());
+        GarbageCollector.collectNative(nativeCacheDir, retainMillis);
+    }
+
+    private static File getUnpackedIndicator(File cachedFile) {
+        return new File(cachedFile.getParent(), cachedFile.getName() + ".unpacked");
+    }
+}

--- a/core/src/main/java/com/threerings/getdown/classpath/cache/ResourceCache.java
+++ b/core/src/main/java/com/threerings/getdown/classpath/cache/ResourceCache.java
@@ -26,13 +26,34 @@ public class ResourceCache
     }
 
     /**
-     * Caches the given file under it's {@code digest}.
-     *
+     * Caches the given file under it's {@code digest}. Same as calling {@link #cacheFile(File, String, boolean)}
+     * with {@code false}
      * @return the cached file
      */
     public File cacheFile (File fileToCache, String digest) throws IOException
     {
-        File cacheLocation = new File(_cacheDir, digest.substring(0, 2));
+        return cacheFile(fileToCache, digest, false);
+    }
+
+    /**
+     * Caches the given file under it's {@code digest}.
+     * @param fileToCache file to cache
+     * @param digest used to determine the name of the directory to store file in
+     * @param useFullHashName if true, the name of the cache directory will not be truncated.
+     *                        This is useful if you need to avoid the possibility of two files
+     *                        sharing a directory.
+     * @return the cached file
+     */
+    public File cacheFile (File fileToCache, String digest, boolean useFullHashName) throws IOException
+    {
+        File cacheLocation;
+
+        if (useFullHashName) {
+            cacheLocation = new File(_cacheDir, digest);
+        } else {
+            cacheLocation = new File(_cacheDir, digest.substring(0, 2));
+
+        }
         createDirectoryIfNecessary(cacheLocation);
 
         File cachedFile = new File(cacheLocation, digest + getFileSuffix(fileToCache));

--- a/core/src/main/java/com/threerings/getdown/data/Resource.java
+++ b/core/src/main/java/com/threerings/getdown/data/Resource.java
@@ -37,13 +37,16 @@ public class Resource implements Comparable<Resource>
         /** Indicates that the resource should be marked executable. */
         EXEC,
         /** Indicates that the resource should be downloaded before a UI is displayed. */
-        PRELOAD
+        PRELOAD,
+        /** Indicates that the resource is a jar containing native libs. */
+        NATIVE
     };
 
     public static final EnumSet<Attr> NORMAL  = EnumSet.noneOf(Attr.class);
     public static final EnumSet<Attr> UNPACK  = EnumSet.of(Attr.UNPACK);
     public static final EnumSet<Attr> EXEC    = EnumSet.of(Attr.EXEC);
     public static final EnumSet<Attr> PRELOAD = EnumSet.of(Attr.PRELOAD);
+    public static final EnumSet<Attr> NATIVE = EnumSet.of(Attr.NATIVE);
 
     /**
      * Computes the MD5 hash of the supplied file.
@@ -211,6 +214,15 @@ public class Resource implements Comparable<Resource>
     {
         return _attrs.contains(Attr.PRELOAD);
     }
+
+    /**
+     * Returns true if this resource is a native lib jar.
+     */
+    public boolean isNativeJar ()
+    {
+        return _attrs.contains(Attr.NATIVE);
+    }
+
 
     /**
      * Computes the MD5 hash of this resource's underlying file.

--- a/core/src/main/java/com/threerings/getdown/util/FileUtil.java
+++ b/core/src/main/java/com/threerings/getdown/util/FileUtil.java
@@ -78,6 +78,27 @@ public class FileUtil
     }
 
     /**
+     * Force deletes {@code file} and all of its children recursively using {@link #deleteHarder}.
+     * Note that some children may still be deleted even if {@code false} is returned. Also, since {@link #deleteHarder}
+     * is used, the {@code file} could be deleted once the jvm exits even if {@code false} is returned.
+     *
+     * @param file file to delete
+     * @return true iff {@code file} was successfully deleted.
+     */
+    public static boolean deleteDirHarder(File file) {
+        if (file.isDirectory()) {
+            for (File child : file.listFiles()) {
+                if (child.isDirectory()) {
+                    deleteDirHarder(child);
+                } else {
+                    deleteHarder(child);
+                }
+            }
+        }
+        return deleteHarder(file);
+    }
+
+    /**
      * Reads the contents of the supplied input stream into a list of lines. Closes the reader on
      * successful or failed completion.
      */
@@ -190,7 +211,7 @@ public class FileUtil
     }
 
     /**
-     * Used by {@link #walkTree}.
+     * Used by {@link #walkTree} and {@link #walkDirectChildren}.
      */
     public interface Visitor
     {
@@ -218,4 +239,21 @@ public class FileUtil
             }
         }
     }
+
+    /**
+     * Walks all direct sub-files of {@code root}, calling {@code visitor} on each file.
+     */
+    public static void walkDirectChildren (final File root, Visitor visitor) {
+        File[] children = root.listFiles();
+
+        if (children == null) return;
+        Deque<File> stack = new ArrayDeque<>(Arrays.asList(children));
+        while (!stack.isEmpty()) {
+            File currentFile = stack.pop();
+            if (currentFile.exists()) {
+                visitor.visit(currentFile);
+            }
+        }
+    }
+
 }

--- a/core/src/test/java/com/threerings/getdown/classpath/ClassPathsTest.java
+++ b/core/src/test/java/com/threerings/getdown/classpath/ClassPathsTest.java
@@ -46,10 +46,10 @@ public class ClassPathsTest
         when(_application.getCodeCacheRetentionDays()).thenReturn(1);
 
         Path firstCachedJarFile = _appdir.getRoot().toPath().
-            resolve(ClassPaths.CACHE_DIR).resolve("fi").resolve("first.jar");
+            resolve(Application.CACHE_DIR + "/code").resolve("fi").resolve("first.jar");
 
         Path secondCachedJarFile = _appdir.getRoot().toPath().
-            resolve(ClassPaths.CACHE_DIR).resolve("se").resolve("second.jar");
+            resolve(Application.CACHE_DIR + "/code").resolve("se").resolve("second.jar");
 
         String expectedClassPath = firstCachedJarFile.toAbsolutePath() + File.pathSeparator +
             secondCachedJarFile.toAbsolutePath();


### PR DESCRIPTION
Originally the only way to add native libraries (.dll, .so etc...) to java.library.path was to either tell Getdown to download each one individually into the root application directory, or tell Getdown to download a jar containing multiple native libs and unpack it. This was especially problematic if you needed to unpack the dlls into a nested directory, because then you'd have to set java.library.path to that nested directory and overwrite the user defined java.library.path (which was trouble if your program relied on this default java.library.path). 

Another issue that we faced was that if an instance of our app was already running (and using any of the dlls), and another instance was launched requiring an updated version of the dll, then Getdown would try to overwrite the existing dll with the new one. Unfortunately this would fail as the dll would already be in use. 

This pull request attempts to fix these issues by caching jars indicated by "nresource", unpacking them, and then adding these cache directories to the system defined java.library.path (and passing that to the application). It also garbage collects based on cache_retention_days, similar to how the existing code cache feature works.  

Some additional notes:
- this could easily be extended to work with .pack.gz files although I didn't bother to do that as it's being deprecated 
- I left 2 TODO comments where I was unsure what to do. You can make your own judgement call with them if you want. 
- I wasn't sure how to handle any non-jar resources (native.dll, picture.png etc), so I left that unchecked and let it throw an error (see NativeLibPath.buildLibsPath()). The fix could be a simple file type check and skip it if it's not a jar. 

Thanks