### PR TITLE
Fix the link to Java WebStart:

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Getdown (yes, it's the funky stuff) is a system for deploying Java applications to end-user
 computers, as well as keeping those applications up to date.
 
-It was designed as a replacement for [Java Web Start](http://java.sun.com/products/javawebstart/)
+It was designed as a replacement for [Java Web Start](https://docs.oracle.com/javase/8/docs/technotes/guides/javaws/)
 due to limitations in Java Web Start's architecture which are outlined in the
 [rationale](https://github.com/threerings/getdown/wiki/Rationale) section.
 


### PR DESCRIPTION
http://java.sun.com/products/javawebstart/
now eventually redirects to:
https://docs.oracle.com/javase/8/docs/technotes/guides/javaws/
So use that for the link.

NOTE: Other options might have been:
https://docs.oracle.com/javase/9/deploy/java-web-start-technology.htm
https://docs.oracle.com/javase/10/deploy/java-web-start-technology.htm

There is no equivalent for Java 11.