### PR TITLE
start GD w/o updating -> directly start app 

### DIFF
--- a/core/src/main/java/com/threerings/getdown/data/SysProps.java
+++ b/core/src/main/java/com/threerings/getdown/data/SysProps.java
@@ -64,6 +64,14 @@ public class SysProps
      return System.getProperty("no_install") != null;
     }
 
+    /**
+     * If true, Getdown launches the app without updating. Usage:
+     * {@code -Dsilent=noupdate}.
+     */
+    public static boolean noUpdate() {
+        return "noupdate".equals(System.getProperty("silent"));
+    }
+
     /** If true, Getdown installs the app without ever bringing up a UI and then launches it.
       * Usage: {@code -Dsilent=launch}. */
     public static boolean launchInSilent () {

--- a/launcher/src/main/java/com/threerings/getdown/launcher/Getdown.java
+++ b/launcher/src/main/java/com/threerings/getdown/launcher/Getdown.java
@@ -270,7 +270,7 @@ public abstract class Getdown extends Thread
                 // and force our UI to be recreated with the updated info
                 createInterfaceAsync(true);
             }
-            if (!_app.lockForUpdates()) {
+            if (!_noUpdate && !_app.lockForUpdates()) {
                 throw new MultipleGetdownRunning();
             }
 

--- a/launcher/src/main/java/com/threerings/getdown/launcher/Getdown.java
+++ b/launcher/src/main/java/com/threerings/getdown/launcher/Getdown.java
@@ -54,6 +54,7 @@ public abstract class Getdown extends Thread
             // launch, start the application after installing. Otherwise, just install and exit.
             _silent = SysProps.silent();
             if (_silent) {
+                _noUpdate = SysProps.noUpdate();
                 _launchInSilent = SysProps.launchInSilent();
             }
             // If we're running in a headless environment and have not otherwise customized
@@ -305,6 +306,13 @@ public abstract class Getdown extends Thread
 
             _toInstallResources = new HashSet<>();
             _readyToInstall = false;
+
+            // directly start the app with the noupdate flag
+            if (_noUpdate) {
+                log.info("Launching without update!");
+                launch();
+                return;
+            }
 
             // setStep(Step.START);
             for (int ii = 0; ii < MAX_LOOPS; ii++) {
@@ -1041,6 +1049,7 @@ public abstract class Getdown extends Thread
 
     protected boolean _dead;
     protected boolean _silent;
+    protected boolean _noUpdate;
     protected boolean _launchInSilent;
     protected long _startup;
 


### PR DESCRIPTION
Some things i've added past years i want to share:

- start application directly w/o update or whatsoever

we have silent, which updates w/o gui
we have silent=noinstall, which downloads, but w/o installing.

And now we have silent=noupdate
Where we just start the application w/o checking even for updates.
This comes handy, if you want to have some own/delayed update check mechanism.
Just start the app with all params provided in gd.txt, no update nor check for it...