### PR TITLE
Avoid overlapping of progress-bar-dialog and proxy-input-panel

### DIFF
--- a/launcher/src/main/java/com/threerings/getdown/launcher/Getdown.java
+++ b/launcher/src/main/java/com/threerings/getdown/launcher/Getdown.java
@@ -148,6 +148,8 @@ public abstract class Getdown extends Thread
             } else {
                 // create a panel they can use to configure the proxy settings
                 _container = createContainer();
+                // allow them to close the window to abort the proxy configuration
+                _dead = true;
                 configureContainer();
                 ProxyPanel panel = new ProxyPanel(this, _msgs);
                 // set up any existing configured proxy
@@ -155,8 +157,6 @@ public abstract class Getdown extends Thread
                 panel.setProxy(hostPort[0], hostPort[1]);
                 _container.add(panel, BorderLayout.CENTER);
                 showContainer();
-                // allow them to close the window to abort the proxy configuration
-                _dead = true;
             }
 
         } catch (Exception e) {


### PR DESCRIPTION
As reported in issue #186, sometimes  the progress-bar-dialog overlaps the proxy-input-panel,
which makes the proxy-input-panel unreadable.
See screen-shots at : https://imgur.com/a/NOR87hz

By moving the _dead=true instructions some line upwards, the problem does not arise anymore.