### PR TITLE
no-arg launch

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+[*]
+charset=utf-8
+end_of_line=lf
+indent_size=2
+indent_style=space
+insert_final_newline=true
+trim_trailing_whitespace = true
+
+[*.java]
+indent_size=4
+
+# also configure imports order manually as follows:
+# import java.*
+# <blank line>
+# import javax.*
+# <blank line>
+# import com.samskivert.*
+# import com.threerings.*
+# import all other imports
+# import static all other imports

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 /*/target/
 /target/
 core/src/main/java/com/threerings/getdown/data/Build.java
+
+# IntelliJ IDEA
+.idea/
+*.iml
+*.ipr
+*.iws

--- a/launcher/src/main/java/com/threerings/getdown/launcher/GetdownApp.java
+++ b/launcher/src/main/java/com/threerings/getdown/launcher/GetdownApp.java
@@ -45,14 +45,9 @@ public class GetdownApp
     public static void main (String[] argv) {
         if (argv.length == 0) {
             // log object should not be used here yet, otherwise it will be initialized incorrectly
-            try {
-                final File jarFile = new File(GetdownApp.class.getProtectionDomain().getCodeSource().getLocation().toURI());
-                String jarDir = jarFile.getParent();
-                argv = new String[]{jarDir};
-                System.out.printf("No args passed, running from current dir. [current dir=%s]\n", jarDir);
-            } catch (Exception e) {
-                System.err.printf("No args passed, failed to fallback to current dir. %s\n", e);
-            }
+            final String workinDir = new File(".").getAbsolutePath();
+            argv = new String[]{workinDir};
+            System.out.printf("No args passed, running from working dir. [working dir=%s]\n", workinDir);
         }
         try {
             start(argv);

--- a/launcher/src/main/java/com/threerings/getdown/launcher/GetdownApp.java
+++ b/launcher/src/main/java/com/threerings/getdown/launcher/GetdownApp.java
@@ -45,9 +45,8 @@ public class GetdownApp
     public static void main (String[] argv) {
         if (argv.length == 0) {
             // log object should not be used here yet, otherwise it will be initialized incorrectly
-            final String workinDir = new File(".").getAbsolutePath();
-            argv = new String[]{workinDir};
-            System.out.printf("No args passed, running from working dir. [working dir=%s]\n", workinDir);
+            argv = new String[]{"."}; // Getdown will properly resolve it later as a working dir
+            System.out.printf("No args passed, running from working dir.");
         }
         try {
             start(argv);

--- a/launcher/src/main/java/com/threerings/getdown/launcher/GetdownApp.java
+++ b/launcher/src/main/java/com/threerings/getdown/launcher/GetdownApp.java
@@ -43,6 +43,17 @@ public class GetdownApp
      * The main entry point of the Getdown launcher application.
      */
     public static void main (String[] argv) {
+        if (argv.length == 0) {
+            // log object should not be used here yet, otherwise it will be initialized incorrectly
+            try {
+                final File jarFile = new File(GetdownApp.class.getProtectionDomain().getCodeSource().getLocation().toURI());
+                String jarDir = jarFile.getParent();
+                argv = new String[]{jarDir};
+                System.out.printf("No args passed, running from current dir. [current dir=%s]\n", jarDir);
+            } catch (Exception e) {
+                System.err.printf("No args passed, failed to fallback to current dir. %s\n", e);
+            }
+        }
         try {
             start(argv);
         } catch (Exception e) {


### PR DESCRIPTION
@samskivert, hi. at some point we decided to bundle JRE with our app and i took some time to search for alternatives. we have few restrictions such as java8 only, standalone deployment (native installers unacceptable) etc. i really liked packr, but when i try to pack getdown our app won't launch because getdown requires app dir as a first arg - but packr cannot provide one.

so my proposal is this: if no any arg is passed then simply assume that current dir is the app dir. i think that's the most common case for most projects using getdown. that will eg allow to use packr with ease.

PS: honestly it's so tedious to pass current dir elsewhere (scripts, launch4j etc), even if it's a dot (java -jar getdown.jar .)