### PR TITLE
Fixed problem with incorrect display of messages in UTF-8 encoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /*/target/
 /target/
 core/src/main/java/com/threerings/getdown/data/Build.java
+/*.idea
+*.iml

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
 /*/target/
 /target/
 core/src/main/java/com/threerings/getdown/data/Build.java
-/*.idea
-*.iml

--- a/launcher/src/main/java/com/threerings/getdown/launcher/Getdown.java
+++ b/launcher/src/main/java/com/threerings/getdown/launcher/Getdown.java
@@ -70,7 +70,7 @@ public abstract class Getdown extends Thread
             // recovering from a security failure
         }
         try {
-            _msgs = ResourceBundle.getBundle("com.threerings.getdown.messages");
+            _msgs = ResourceBundle.getBundle("com.threerings.getdown.messages",  new UTFControl());
         } catch (Exception e) {
             // welcome to hell, where java can't cope with a classpath that contains jars that live
             // in a directory that contains a !, at least the same bug happens on all platforms

--- a/launcher/src/main/java/com/threerings/getdown/launcher/UTFControl.java
+++ b/launcher/src/main/java/com/threerings/getdown/launcher/UTFControl.java
@@ -1,0 +1,43 @@
+package com.threerings.getdown.launcher;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.Locale;
+import java.util.PropertyResourceBundle;
+import java.util.ResourceBundle;
+
+public class UTFControl extends ResourceBundle.Control {
+    public ResourceBundle newBundle
+            (String baseName, Locale locale, String format, ClassLoader loader, boolean reload)
+            throws IllegalAccessException, InstantiationException, IOException {
+
+        String bundleName = toBundleName(baseName, locale);
+        String resourceName = toResourceName(bundleName, "properties");
+        ResourceBundle bundle = null;
+        InputStream stream = null;
+        if (reload) {
+            URL url = loader.getResource(resourceName);
+            if (url != null) {
+                URLConnection connection = url.openConnection();
+                if (connection != null) {
+                    connection.setUseCaches(false);
+                    stream = connection.getInputStream();
+                }
+            }
+        } else {
+            stream = loader.getResourceAsStream(resourceName);
+        }
+        if (stream != null) {
+            try {
+                // Only this line is changed to make it to read properties files as UTF-8.
+                bundle = new PropertyResourceBundle(new InputStreamReader(stream, "UTF-8"));
+            } finally {
+                stream.close();
+            }
+        }
+        return bundle;
+    }
+}


### PR DESCRIPTION
Fixed problem with incorrect display of messages in UTF-8 encoding.
I guess this is due to the utf-8 encoding of the file messages_ru.properties

Before
![getdown1](https://user-images.githubusercontent.com/5947316/56742720-edd14a80-677d-11e9-95ca-b32855d8005d.png)
After
![getdown2](https://user-images.githubusercontent.com/5947316/56742725-f033a480-677d-11e9-9714-4c1a100062b4.png)
