### PR TITLE
fixed exception logging

### DIFF
--- a/core/src/main/java/com/threerings/getdown/Log.java
+++ b/core/src/main/java/com/threerings/getdown/Log.java
@@ -9,6 +9,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.text.FieldPosition;
 import java.text.SimpleDateFormat;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.logging.*;
 
@@ -58,6 +59,7 @@ public class Log
                     err = (Throwable)message;
                 } else if (nn % 2 == 1 && (args[nn - 1] instanceof Throwable)) {
                     err = (Throwable)args[--nn];
+                    args = Arrays.copyOfRange(args, 0, nn);
                 }
                 _impl.log(LEVELS[levIdx], format(message, args), err);
             }
@@ -69,6 +71,11 @@ public class Log
     /** We dispatch our log messages through this logging shim. */
     public static final Shim log = new Shim();
 
+    /**
+     * @param message just message
+     * @param args should have even length
+     * @return message with nicely formatted args like "message [arg0=arg1, arg2=arg3, ...]
+     */
     public static String format (Object message, Object... args) {
         if (args.length < 2) return String.valueOf(message);
         StringBuilder buf = new StringBuilder(String.valueOf(message));
@@ -136,6 +143,5 @@ public class Log
         protected FieldPosition _fpos = new FieldPosition(SimpleDateFormat.DATE_FIELD);
     }
 
-    protected static final String DATE_FORMAT = "{0,date} {0,time}";
     protected static final Level[] LEVELS = {Level.FINE, Level.INFO, Level.WARNING, Level.SEVERE};
 }

--- a/core/src/test/java/com/threerings/getdown/LogTest.java
+++ b/core/src/test/java/com/threerings/getdown/LogTest.java
@@ -1,0 +1,44 @@
+package com.threerings.getdown;
+
+import java.io.FileNotFoundException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
+
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+public class LogTest {
+    @Test
+    public void testLog() {
+        // given
+        final List<LogRecord> logRecords = new ArrayList<>();
+        final FileNotFoundException ex = new FileNotFoundException("patch.dat");
+
+        class TestHandler extends Handler {
+            @Override
+            public void publish (LogRecord logRecord) {
+                logRecords.add(logRecord);
+            }
+
+            @Override
+            public void flush () {
+            }
+
+            @Override
+            public void close () throws SecurityException {
+            }
+        }
+
+        Log.log._impl.addHandler(new TestHandler());
+
+        // when
+        Log.log.warning("Download failed", "rsrc", "Resource", ex);
+
+        // then
+        assertEquals("Download failed [rsrc=Resource]", logRecords.get(0).getMessage());
+        assertSame(ex, logRecords.get(0).getThrown());
+    }
+}


### PR DESCRIPTION
@samskivert, hi. found small issue in logger. w/o fix:
```
...
2019/05/05 20:24:49:266 INFO Application requires update.
2019/05/05 20:29:53:149 WARNING Download failed [rsrc=patch201904141803.dat, java.io.FileNotFoundException: http://app/files/201905051855/patch201904141803.dat=<toString() failure: java.lang.ArrayIndexOutOfBoundsException: 3>]
java.io.FileNotFoundException: http://app/files/201905051855/patch201904141803.dat
...
```
wrote a test which initially failed:
```
Expected :Download failed [rsrc=Resource]
Actual   :Download failed [rsrc=Resource, java.io.FileNotFoundException: patch.dat=<toString() failure: java.lang.ArrayIndexOutOfBoundsException: 3>]
```

i got a question though. why not change Log.format method to accept ``Map<String, Object>`` instead of ``Object[]``? Map is verbose to write of course but better reflects method requirements and less error-prone.