### PR TITLE
Fix bug on mac while regenerating classes.jsa when path to java contains spaces

### DIFF
--- a/launcher/src/main/java/com/threerings/getdown/launcher/Getdown.java
+++ b/launcher/src/main/java/com/threerings/getdown/launcher/Getdown.java
@@ -525,9 +525,10 @@ public abstract class Getdown extends Thread
 
         // lastly regenerate the .jsa dump file that helps Java to start up faster
         String vmpath = LaunchUtil.getJVMBinaryPath(javaLocalDir, false);
+		String[] command = new String[]{vmpath, "-Xshare:dump"};
         try {
             log.info("Regenerating classes.jsa for " + vmpath + "...");
-            Runtime.getRuntime().exec(vmpath + " -Xshare:dump");
+            Runtime.getRuntime().exec(command);
         } catch (Exception e) {
             log.warning("Failed to regenerate .jsa dump file", "error", e);
         }

--- a/launcher/src/main/java/com/threerings/getdown/launcher/Getdown.java
+++ b/launcher/src/main/java/com/threerings/getdown/launcher/Getdown.java
@@ -525,7 +525,7 @@ public abstract class Getdown extends Thread
 
         // lastly regenerate the .jsa dump file that helps Java to start up faster
         String vmpath = LaunchUtil.getJVMBinaryPath(javaLocalDir, false);
-		String[] command = new String[]{vmpath, "-Xshare:dump"};
+        String[] command = new String[]{vmpath, "-Xshare:dump"};
         try {
             log.info("Regenerating classes.jsa for " + vmpath + "...");
             Runtime.getRuntime().exec(command);


### PR DESCRIPTION
Title is self-explanatory. The bug doesn't allow classes.jsa to be generated (and warning is logged) and launch time is bigger. The code fixes it. 
Also, the code has been tested and confirmed working on windows and mac, both with and without spaces in file paths.