### PR TITLE
allow appbase and latest URL to use ENV variables too

### DIFF
--- a/core/src/main/java/com/threerings/getdown/data/Application.java
+++ b/core/src/main/java/com/threerings/getdown/data/Application.java
@@ -587,7 +587,7 @@ public class Application
         }
 
         // check if we're overriding the domain in the appbase
-        _appbase = SysProps.overrideAppbase(_appbase);
+        _appbase = processArg(SysProps.overrideAppbase(_appbase));
 
         // make sure there's a trailing slash
         if (!_appbase.endsWith("/")) {
@@ -606,7 +606,7 @@ public class Application
         }
 
         // check for a latest config URL
-        String latest = config.getString("latest");
+        String latest = processArg(config.getString("latest"));
         if (latest != null) {
             if (latest.startsWith(_appbase)) {
                 latest = _appbase + latest.substring(_appbase.length());
@@ -1121,6 +1121,10 @@ public class Application
     /** Replaces the application directory and version in any argument. */
     protected String processArg (String arg)
     {
+        if (arg == null) {
+            return null;
+        }
+
         arg = arg.replace("%APPDIR%", getAppDir().getAbsolutePath());
         arg = arg.replace("%VERSION%", String.valueOf(_version));
 


### PR DESCRIPTION
We need to be able to perform canary deployments of new versions with specific workstations. This change allows to use latest/appbase URLs to provide GET parameters, e.g. : http://xyz.com/app/getdown.txt?NODE=%ENV.COMPUTERNAME%
This way a servlet on the backend can provide different getdown.txt depending on the computername.