### PR TITLE
Provide default implementation for pac sandbox function myIpAddress

### DIFF
--- a/launcher/src/main/resources/com/threerings/getdown/launcher/PacUtils.js
+++ b/launcher/src/main/resources/com/threerings/getdown/launcher/PacUtils.js
@@ -49,6 +49,21 @@ function isResolvable (host) {
   return (ip != null);
 }
 
+
+
+/**
+ *  The myIpAddress() function is inconsistently implemented across the major web browsers and doesn’t support IPv6
+ *  this may result in either an IPv6 address being returned unexpectedly, 127.0.0.1 being returned, or the IP address of an unexpected network adapter being returned. As such it’s recommended to avoid use of this function completely. Windows has implemented a new FindProxyForURLEx() function to support IPv6
+ *  however, the implementation is complex and support across the major browsers is lacking.
+ *  Since myIpAddress() function is widely used in pac-files although it should not, and since jdk's Nashorn engine does not implement it, return address 127.0.0.1 
+ */
+function myIpAddress()
+{
+    return '127.0.0.1';
+}
+
+
+
 function localHostOrDomainIs (host, hostdom) {
   return (host == hostdom) || (hostdom.lastIndexOf(host + '.', 0) == 0);
 }


### PR DESCRIPTION
http://findproxyforurl.com/pac-functions/

This in order to avoid
javax.script.ScriptException: ReferenceError: "myIpAddress" is not defined in at line number 67
at jdk.scripting.nashorn/jdk.nashorn.api.scripting.NashornScriptEngine.throwAsScriptException(Unknown Source)
at jdk.scripting.nashorn/jdk.nashorn.api.scripting.NashornScriptEngine.invokeImpl(Unknown Source)
at jdk.scripting.nashorn/jdk.nashorn.api.scripting.NashornScriptEngine.invokeFunction(Unknown Source)
at com.threerings.getdown.launcher.ProxyUtil.findPACProxiesForURL(ProxyUtil.java:301)
at com.threerings.getdown.launcher.ProxyUtil.autoDetectProxy(ProxyUtil.java:127)
at com.threerings.getdown.launcher.Getdown.detectProxy(Getdown.java:205)
at com.threerings.getdown.launcher.Getdown.run(Getdown.java:190)
at com.threerings.getdown.launcher.Getdown$2.run(Getdown.java:72)