### PR TITLE
No engine available

### DIFF
--- a/launcher/src/main/java/com/threerings/getdown/launcher/ProxyUtil.java
+++ b/launcher/src/main/java/com/threerings/getdown/launcher/ProxyUtil.java
@@ -252,12 +252,12 @@ public final class ProxyUtil {
     }
 
     public static String[] findPACProxiesForURL (Reader pac, URL url) {
-        ScriptEngineManager manager = new ScriptEngineManager();
-        ScriptEngine engine = manager.getEngineByName("javascript");
-        Bindings globals = engine.createBindings();
-        globals.put("resolver", new Resolver());
-        engine.setBindings(globals, ScriptContext.GLOBAL_SCOPE);
         try {
+        	ScriptEngineManager manager = new ScriptEngineManager();
+            ScriptEngine engine = manager.getEngineByName("javascript");
+            Bindings globals = engine.createBindings();
+            globals.put("resolver", new Resolver());
+            engine.setBindings(globals, ScriptContext.GLOBAL_SCOPE);
             URL utils = ProxyUtil.class.getResource("PacUtils.js");
             if (utils == null) {
                 log.error("Unable to load PacUtils.js");

--- a/launcher/src/main/java/com/threerings/getdown/launcher/ProxyUtil.java
+++ b/launcher/src/main/java/com/threerings/getdown/launcher/ProxyUtil.java
@@ -274,7 +274,7 @@ public final class ProxyUtil {
                 proxies[ii] = proxies[ii].trim();
             }
             return proxies;
-        } catch (Exception e) {
+        } catch (Exception | NoClassDefFoundError e) {
             log.warning("Failed to resolve PAC proxy", e);
         }
         return new String[0];


### PR DESCRIPTION
Nowadays often VM runtimes are build with jlink specifying the needed modules.
It is therefore not guaranteed more  that the Runtime has an ScriptEngineManager class in the classpath.

At the moment the launcher will abort with a stacktrace like following:
Exception in thread "Getdown" java.lang.NoClassDefFoundError: javax/script/ScriptEngineManager
	at com.threerings.getdown.launcher.ProxyUtil.findPACProxiesForURL(ProxyUtil.java:326)
	at com.threerings.getdown.launcher.ProxyUtil.autoDetectProxy(ProxyUtil.java:138)
	at com.threerings.getdown.launcher.Getdown.detectProxy(Unknown Source)
	at com.threerings.getdown.launcher.Getdown.run(Unknown Source)
	at com.threerings.getdown.launcher.a.run(Unknown Source)
Caused by: java.lang.ClassNotFoundException: javax.script.ScriptEngineManager
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(Unknown Source)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(Unknown Source)
	at java.base/java.lang.ClassLoader.loadClass(Unknown Source)
	... 5 more

With the PR the launcher will go ahead after the exception:
2019/06/06 10:38:06:139 INFO Using appdir from command line: .
2019/06/06 10:38:06:139 INFO ------------------ VM Info ------------------
2019/06/06 10:38:06:139 INFO -- OS Name: Windows 10
2019/06/06 10:38:06:139 INFO -- OS Arch: amd64
2019/06/06 10:38:06:139 INFO -- OS Vers: 10.0
2019/06/06 10:38:06:139 INFO -- Java Vers: 11.0.2
2019/06/06 10:38:06:139 INFO -- Java Home: C:\Users\pb00067\AppData\Local\WUERTHPHOENIX CIS\TestServer5\java_getdown_vm
2019/06/06 10:38:06:139 INFO -- User Name: pb00067
2019/06/06 10:38:06:139 INFO -- User Home: C:\Users\pb00067
2019/06/06 10:38:06:139 INFO -- Cur dir: C:\Users\pb00067\AppData\Local\WUERTHPHOENIX CIS\TestServer5
2019/06/06 10:38:06:139 INFO ---------------------------------------------
2019/06/06 10:38:06:163 INFO Getdown starting [version=1.8.6, built=2019-06-04 15:27]
2019/06/06 10:38:06:164 INFO Checking whether we need to use a proxy...
2019/06/06 10:38:06:175 INFO Now trying to read windows registry using reg query tool..
2019/06/06 10:38:06:232 INFO PAC-ConfigURL: http://10.62.7.213:8080/cis/proxy-wgs.pac
2019/06/06 10:38:06:302 WARNING Failed to resolve PAC proxy
java.lang.NoClassDefFoundError: javax/script/ScriptEngineManager
	at com.threerings.getdown.launcher.ProxyUtil.findPACProxiesForURL(ProxyUtil.java:328)
	at com.threerings.getdown.launcher.ProxyUtil.autoDetectProxy(ProxyUtil.java:138)
	at com.threerings.getdown.launcher.Getdown.detectProxy(Unknown Source)
	at com.threerings.getdown.launcher.Getdown.run(Unknown Source)
	at com.threerings.getdown.launcher.a.run(Unknown Source)
Caused by: java.lang.ClassNotFoundException: javax.script.ScriptEngineManager
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(Unknown Source)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(Unknown Source)
	at java.base/java.lang.ClassLoader.loadClass(Unknown Source)
	... 5 more
2019/06/06 10:38:06:392 INFO Attempting to fetch without proxy: http://10.62.6.195:8080/cis/getdown/getdown.txt
2019/06/06 10:38:06:418 INFO No proxy appears to be needed.
2019/06/06 10:38:06:426 INFO Able to lock for updates: true
2019/06/06 10:38:06:427 INFO Verifying application: http://10.62.6.195:8080/cis/getdown/
2019/06/06 10:38:06:427 INFO Version: -1
2019/06/06 10:38:06:428 INFO Class: com.wuerth.phoenix.cis.ulc.client.CisStandaloneLauncher
2019/06/06 10:38:06:448 INFO Attempting to refetch 'digest.txt' from 'http://10.62.6.195:8080/cis/getdown/digest.txt'.
2019/06/06 10:38:06:477 INFO No signing certs, not verifying digest.txt [path=digest.txt]
2019/06/06 10:38:06:485 INFO Attempting to refetch 'digest2.txt' from 'http://10.62.6.195:8080/cis/getdown/digest2.txt'.
2019/06/06 10:38:06:507 INFO No signing certs, not verifying digest.txt [path=digest2.txt]
2019/06/06 10:38:06:530 INFO Verified resources [count=8, alreadyValid=8, size=3759k, duration=6ms]
2019/06/06 10:38:06:532 INFO Checking Java version [current=11000200, wantMin=11000201, wantMax=0]
2019/06/06 10:38:06:536 INFO Checking version of unpacked JVM [vers=11000201].
2019/06/06 10:38:06:536 INFO Nothing to install.
.....