### PR TITLE
replace "MISSING:" with "MISSING-" to avoid MalformedUrlException

### DIFF
--- a/core/src/main/java/com/threerings/getdown/data/Application.java
+++ b/core/src/main/java/com/threerings/getdown/data/Application.java
@@ -1147,7 +1147,7 @@ public class Application
             Matcher matcher = ENV_VAR_PATTERN.matcher(text);
             while (matcher.find()) {
                 String varName = matcher.group(1), varValue = System.getenv(varName);
-                String repValue = varValue == null ? "MISSING:"+varName : varValue;
+                String repValue = varValue == null ? "MISSING-"+varName : varValue;
                 matcher.appendReplacement(sb, Matcher.quoteReplacement(repValue));
             }
             matcher.appendTail(sb);


### PR DESCRIPTION
...when digesting/diffing app with undefined variables (during build time) in appbase/latest.

The variables we added to appbase (e.g. https://%ENV.ADMIN-SERVER%/....) work fine with 1.8.7-SNAPSHOT launcher. But since digester and differ are running on a build machine, where the variables are not set, the " _vappbase = createVAppBase(_version);" in Application.initBase() causes the build to fail with MalformedURLException if the missing variable inserts a ":" .