### PR TITLE
Add glob 'cleanup_pattern' to remove obsolete resources

### DIFF
--- a/core/src/main/java/com/threerings/getdown/data/Application.java
+++ b/core/src/main/java/com/threerings/getdown/data/Application.java
@@ -363,6 +363,13 @@ public class Application
     }
 
     /**
+     * Returns a list of the cleanup patterns used by application.
+     */
+    public List<String> cleanupPatterns() {
+        return _cleanupPatterns;
+    }
+
+    /**
      * Returns a list of all the active {@link Resource} objects used by this application (code and
      * non-code).
      */
@@ -594,6 +601,7 @@ public class Application
         initJava(config);
         initTracking(config);
         initResources(config);
+        initCleanupPatterns(config);
         initArgs(config);
         return config;
     }
@@ -751,6 +759,22 @@ public class Application
             parseResources(config, auxgroup + ".nresource", Resource.NATIVE, rsrcs);
             _auxgroups.put(auxgroup, new AuxGroup(auxgroup, codes, rsrcs));
         }
+    }
+
+    /**
+     * Reads the cleanup patterns from {@code config} into this instance.
+     */
+    public void initCleanupPatterns (Config config) {
+        // clear our arrays as we may be reinitializing
+        _cleanupPatterns.clear();
+
+        // parse cleanup patterns
+        String[] patterns = config.getMultiValue("cleanup_pattern");
+        if (patterns == null) {
+            return;
+        }
+
+        _cleanupPatterns.addAll(Arrays.asList(patterns));
     }
 
     /**
@@ -1771,6 +1795,7 @@ public class Application
 
     protected List<Resource> _codes = new ArrayList<>();
     protected List<Resource> _resources = new ArrayList<>();
+    protected List<String> _cleanupPatterns = new ArrayList<>();
     protected List<String> _cpdirs = new ArrayList<>();
 
     protected int _verifyTimeout = 60;

--- a/launcher/src/main/java/com/threerings/getdown/launcher/Getdown.java
+++ b/launcher/src/main/java/com/threerings/getdown/launcher/Getdown.java
@@ -22,6 +22,7 @@ import java.io.InputStreamReader;
 import java.io.PrintStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.file.*;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -424,6 +425,12 @@ public abstract class Getdown
                 _readyToInstall = true;
                 install();
 
+                // do resource cleanup
+                final List<String> cleanupPatterns = _app.cleanupPatterns();
+                if (!cleanupPatterns.isEmpty()) {
+                    cleanupResources(cleanupPatterns);
+                }
+
                 // Only launch if we aren't in silent mode. Some mystery program starting out
                 // of the blue would be disconcerting.
                 if (!_silent || _launchInSilent) {
@@ -676,6 +683,37 @@ public abstract class Getdown
         if (!dl.download(resources, _app.maxConcurrentDownloads())) {
             // if we aborted due to detecting another getdown running, we want to report here
             throw new MultipleGetdownRunning();
+        }
+    }
+
+    /**
+     * Removes files/resources by glob pattern with exclusion of resources defined in Getdown.txt
+     */
+    void cleanupResources(List<String> cleanupPatterns) {
+        //get list of files from glob patterns
+        final String applicationPath = _app.getAppDir().getAbsolutePath();
+        final Set<Path> filesFromGlob = new HashSet<>();
+        for (String cleanupPattern : cleanupPatterns) {
+            filesFromGlob.addAll(FileUtil.getFilePathsByGlob(applicationPath, cleanupPattern));
+        }
+
+        //filter out files contained in resources
+        Set<Path> rsrcs = new HashSet<>();
+        for (Resource resource : _app.getAllActiveResources()) {
+            rsrcs.add(resource.getLocal().toPath().toAbsolutePath());
+        }
+
+        final Set<Path> cleanupSet = new HashSet<>();
+        for (Path path : filesFromGlob) {
+            if (!rsrcs.contains(path)) {
+                cleanupSet.add(path);
+            }
+        }
+
+        if (!cleanupSet.isEmpty()) {
+            for (Path path : cleanupSet) {
+                path.toFile().delete();
+            }
         }
     }
 

--- a/launcher/src/main/java/com/threerings/getdown/launcher/Getdown.java
+++ b/launcher/src/main/java/com/threerings/getdown/launcher/Getdown.java
@@ -343,6 +343,13 @@ public abstract class Getdown
                 if (_app.verifyMetadata(this)) {
                     log.info("Application requires update.");
                     update();
+
+                    // do resource cleanup
+                    final List<String> cleanupPatterns = _app.cleanupPatterns();
+                    if (!cleanupPatterns.isEmpty()) {
+                        cleanupResources(cleanupPatterns);
+                    }
+
                     // loop back again and reverify the metadata
                     continue;
                 }
@@ -424,12 +431,6 @@ public abstract class Getdown
                 // assuming we're not doing anything funny, install the update
                 _readyToInstall = true;
                 install();
-
-                // do resource cleanup
-                final List<String> cleanupPatterns = _app.cleanupPatterns();
-                if (!cleanupPatterns.isEmpty()) {
-                    cleanupResources(cleanupPatterns);
-                }
 
                 // Only launch if we aren't in silent mode. Some mystery program starting out
                 // of the blue would be disconcerting.


### PR DESCRIPTION
Hello, 

We noticed that over time obsolete resources accumulate in Getdown folder. This PR allows to define optional list of Glob patterns in Getdown.txt, like:
```
cleanup_pattern = lib\*.jar
cleanup_pattern = rsrcs\*.jpg
cleanup_pattern = old_*.png
```

Glob patterns are defined relative to 'getdown' folder.  
In this case Getdown would collect list for files from the patterns, that is cross-check against resources specified in Getdown.txt. Then only the files that are not in getdown resource list, will be removed.

Potentially closes #183