### PR TITLE
Use relative paths in classpath to shorten execution line on large apps

### DIFF
--- a/core/src/main/java/com/threerings/getdown/data/Application.java
+++ b/core/src/main/java/com/threerings/getdown/data/Application.java
@@ -1009,7 +1009,7 @@ public class Application
         ClassPath classPath = PathBuilder.buildClassPath(this);
         if (!dashJarMode) {
             args.add("-classpath");
-            args.add(classPath.asArgumentString());
+            args.add(classPath.asArgumentString(getAppDir()));
         }
 
         // we love our Mac users, so we do nice things to preserve our application identity
@@ -1028,7 +1028,7 @@ public class Application
         // @TODO optional getdown.txt parameter to set addCurrentLibraryPath to true or false?
         ClassPath javaLibPath = PathBuilder.buildLibsPath(this, true);
         if (javaLibPath != null) {
-            args.add("-Djava.library.path=" + javaLibPath.asArgumentString());
+            args.add("-Djava.library.path=" + javaLibPath.asArgumentString(getAppDir()));
         }
 
         // pass along any pass-through arguments
@@ -1060,7 +1060,7 @@ public class Application
         // if we're in -jar mode add those arguments, otherwise add the app class name
         if (dashJarMode) {
             args.add("-jar");
-            args.add(classPath.asArgumentString());
+            args.add(classPath.asArgumentString(getAppDir()));
         } else {
             args.add(_class);
         }

--- a/core/src/main/java/com/threerings/getdown/data/ClassPath.java
+++ b/core/src/main/java/com/threerings/getdown/data/ClassPath.java
@@ -31,13 +31,17 @@ public class ClassPath
      * <pre>
      *   /path/to/a.jar:/path/to/b.jar
      * </pre>
+     *
+     * The paths are relativized to dir.
+     *
+     * @param dir the working directory of the process
      */
-    public String asArgumentString ()
+    public String asArgumentString (File dir)
     {
         StringBuilder builder = new StringBuilder();
         String delimiter = "";
         for (File entry: _classPathEntries) {
-            builder.append(delimiter).append(entry.getAbsolutePath());
+            builder.append(delimiter).append(dir.toPath().relativize(entry.toPath()));
             delimiter = File.pathSeparator;
         }
         return builder.toString();

--- a/core/src/test/java/com/threerings/getdown/data/ClassPathTest.java
+++ b/core/src/test/java/com/threerings/getdown/data/ClassPathTest.java
@@ -36,8 +36,8 @@ public class ClassPathTest
     @Test public void shouldCreateValidArgumentString ()
     {
         assertEquals(
-            _firstJar.getAbsolutePath() + File.pathSeparator + _secondJar.getAbsolutePath(),
-            _classPath.asArgumentString());
+            "a.jar:b.jar",
+            _classPath.asArgumentString(_folder.getRoot()));
     }
 
     @Test public void shouldProvideJarUrls () throws MalformedURLException, URISyntaxException

--- a/core/src/test/java/com/threerings/getdown/data/PathBuilderTest.java
+++ b/core/src/test/java/com/threerings/getdown/data/PathBuilderTest.java
@@ -36,9 +36,7 @@ public class PathBuilderTest
     @Test public void shouldBuildDefaultClassPath () throws IOException
     {
         ClassPath classPath = PathBuilder.buildDefaultClassPath(_application);
-        String expectedClassPath = _firstJarFile.getAbsolutePath() + File.pathSeparator +
-            _secondJarFile.getAbsolutePath();
-        assertEquals(expectedClassPath, classPath.asArgumentString());
+        assertEquals("a.jar:b.jar", classPath.asArgumentString(_appdir.getRoot()));
     }
 
     @Test public void shouldBuildCachedClassPath () throws IOException
@@ -47,17 +45,8 @@ public class PathBuilderTest
         when(_application.getDigest(_secondJar)).thenReturn("second");
         when(_application.getCodeCacheRetentionDays()).thenReturn(1);
 
-        Path firstCachedJarFile = _appdir.getRoot().toPath().
-            resolve(PathBuilder.CODE_CACHE_DIR).resolve("fi").resolve("first.jar");
-
-        Path secondCachedJarFile = _appdir.getRoot().toPath().
-            resolve(PathBuilder.CODE_CACHE_DIR).resolve("se").resolve("second.jar");
-
-        String expectedClassPath = firstCachedJarFile.toAbsolutePath() + File.pathSeparator +
-            secondCachedJarFile.toAbsolutePath();
-
         ClassPath classPath = PathBuilder.buildCachedClassPath(_application);
-        assertEquals(expectedClassPath, classPath.asArgumentString());
+        assertEquals(".cache/fi/first.jar:.cache/se/second.jar", classPath.asArgumentString(_appdir.getRoot()));
     }
 
     @Mock protected Application _application;


### PR DESCRIPTION
Hej samskivert,

our app has more than 250 libs (please don't ask why) and will be placed at %APPDATA%/myapp with code-cache enabled.  So the final execution line has a very long argument for classpath, which results in an error at launch on windows (see [string limitations for cmd](https://docs.microsoft.com/en-us/troubleshoot/windows-client/shell-experience/command-line-string-limitation#:~:text=The%20maximum%20length%20of%20the,such%20as%20the%20PATH%20variable)). I noticed that the working dir will be set to the app-dir in getdown, so in my opinion absolute paths are unnecessary on classpath. 

With the change to relative paths, our fat-app is starting! Check my changes and I'm looking forward to hearing from you.

Greetings from Germany (Münster),
Ben