### PR TITLE
Moved resource cleanup to install for support of unversioned-mode

### DIFF
--- a/launcher/src/main/java/com/threerings/getdown/launcher/Getdown.java
+++ b/launcher/src/main/java/com/threerings/getdown/launcher/Getdown.java
@@ -138,6 +138,12 @@ public abstract class Getdown
             _toInstallResources.clear();
             _readyToInstall = false;
             log.info("Install completed.");
+
+            // do resource cleanup
+            final List<String> cleanupPatterns = _app.cleanupPatterns();
+            if (!cleanupPatterns.isEmpty()) {
+                cleanupResources(cleanupPatterns);
+            }
         } else {
             log.info("Nothing to install.");
         }
@@ -343,12 +349,6 @@ public abstract class Getdown
                 if (_app.verifyMetadata(this)) {
                     log.info("Application requires update.");
                     update();
-
-                    // do resource cleanup
-                    final List<String> cleanupPatterns = _app.cleanupPatterns();
-                    if (!cleanupPatterns.isEmpty()) {
-                        cleanupResources(cleanupPatterns);
-                    }
 
                     // loop back again and reverify the metadata
                     continue;


### PR DESCRIPTION
This change fixes the cleanup of resources by glob-pattern for unversioned-mode, which is broken after commit [332f7f1](https://github.com/threerings/getdown/commit/332f7f15e381fb10347b527dbc72327ee3d18be5), but keeps the optimisation to only perform cleanups on updates.