### PR TITLE
Update Rectangle.java - Add default and width-height constructors to …

### DIFF
--- a/core/src/main/java/com/threerings/getdown/util/Rectangle.java
+++ b/core/src/main/java/com/threerings/getdown/util/Rectangle.java
@@ -1,8 +1,3 @@
-//
-// Getdown - application installer, patcher and launcher
-// Copyright (C) 2004-2018 Getdown authors
-// https://github.com/threerings/getdown/blob/master/LICENSE
-
 package com.threerings.getdown.util;
 
 /**
@@ -15,8 +10,18 @@ public class Rectangle
     public final int width;
     public final int height;
 
-    public Rectangle (int x, int y, int width, int height)
-    {
+    // New: zero-argument constructor
+    public Rectangle() {
+        this(0, 0, 0, 0);
+    }
+
+    // New: width & height only constructor
+    public Rectangle(int width, int height) {
+        this(0, 0, width, height);
+    }
+
+    // Existing: full constructor
+    public Rectangle(int x, int y, int width, int height) {
         this.x = x;
         this.y = y;
         this.width = width;


### PR DESCRIPTION
…Rectangle

Add default and width-height constructors to Rectangle This PR adds two convenience constructors:
- A zero-argument constructor for a (0,0,0,0) rectangle.
- A width-height constructor to create a rectangle at origin.

This improves usability for callers who want simple rectangle defaults without manually specifying x and y.